### PR TITLE
Add wait-for-operators scripting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -217,3 +217,7 @@ runs:
       run: |
         oc adm policy add-scc-to-user privileged user
         oc adm policy add-scc-to-group privileged system:authenticated
+
+    - name: Wait for operators to be available
+      shell: bash
+      run: ./scripts/wait-for-operators.sh

--- a/scripts/wait-for-operators.sh
+++ b/scripts/wait-for-operators.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+timeout=600  # 10 minutes in seconds
+elapsed=0
+interval=10
+
+while true; do
+  if oc get co --no-headers | awk '{if ($3 != "True" || $4 != "False") exit 1}'; then
+    echo "All operators are available and not progressing"
+    break
+  else
+    echo "Waiting for operators to become available..."
+    sleep $interval
+    elapsed=$((elapsed + interval))
+    if [ $elapsed -ge $timeout ]; then
+      echo "Timeout reached: Not all operators are available"
+      exit 1
+    fi
+  fi
+done


### PR DESCRIPTION
Wait for operators to be all `Available` before ending the action.