### PR TITLE
Add optional flag to wait for operators to be healthy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Cache the crc bundles for faster startup'
     required: false
     default: 'false'
+  waitForOperatorsReady:
+    description: 'Wait for all operators to be ready'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -219,5 +223,6 @@ runs:
         oc adm policy add-scc-to-group privileged system:authenticated
 
     - name: Wait for operators to be available
+      if: ${{ inputs.waitForOperatorsReady == 'true' }}
       shell: bash
       run: ${{ github.action_path }}/scripts/wait-for-operators.sh


### PR DESCRIPTION
Similar to: https://github.com/palmsoftware/quick-k8s/pull/17

Adds a new flag for `waitForOperatorsReady`.