### PR TITLE
Resolve ubuntu-24-errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,14 @@ runs:
       if: ${{ matrix.os == 'ubuntu-24.04' }}
       shell: bash
       run: |
-        sudo apt-get install -y virtiofsd
+        sudo apt-get update
+        sudo apt-get install -y virtiofsd libvirt-daemon-system libvirt-daemon-driver-qemu
+        if systemctl list-unit-files | grep -q virtqemud.socket; then
+          sudo systemctl enable virtqemud.socket
+          sudo systemctl start virtqemud.socket
+        else
+          echo "virtqemud.socket unit file does not exist. Skipping enable/start steps."
+        fi
 
     - name: Enable KVM group perms
       shell: bash


### PR DESCRIPTION
Ubuntu 24 errors are happening in some runs.  Adding some additional packages to help fix the problem.

Key changes:

### Dependency installation updates:
* Added commands to update the package list before installation and included additional dependencies: `qemu`, `libvirt-daemon-system`, and `libvirt-daemon-driver-qemu`.

### Service configuration:
* Added commands to enable and start the `virtqemud.socket` service to ensure proper functionality of the virtualization setup.