### PR TITLE
Add functionality to use different OCP versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
-        ocp: [4.14, 4.16, 4.17, 4.18]
+        ocp: [4.17, 4.18, latest]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
+        ocp: [4.14, 4.16, 4.17, 4.18]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash
@@ -29,5 +30,6 @@ jobs:
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
+          desiredOCPVersion: ${{ matrix.ocp }}
         env:
           OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
+        ocp: [4.14, 4.16, 4.17, 4.18, latest]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash
@@ -31,5 +32,6 @@ jobs:
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
+          desiredOCPVersion: ${{ matrix.ocp }}
         env:
           OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
-        ocp: [4.14, 4.16, 4.17, 4.18, latest]
+        ocp: [4.17, 4.18, latest]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/README.md
+++ b/README.md
@@ -36,3 +36,18 @@ This is development only environment that is provided by Red Hat that will allow
 ## References
 
 - [install-oc-tools.sh](./scripts/install-oc-tools.sh) was a script copied from [install-oc-tools](https://github.com/cptmorgan-rh/install-oc-tools) and slightly modified for `aarch64`.
+
+## OpenShift Version Selection
+
+You can control which OpenShift version is deployed by setting the `desiredOCPVersion` input variable. For example:
+
+```yaml
+with:
+  desiredOCPVersion: 4.18
+```
+
+- The default is `latest`, which will use the most recent supported version.  If you leave `desiredOCPVersion` blank, you will get the latest version.
+- Supported values are `4.14`, `4.16`, `4.17`, `4.18`, and any other version supported by the CRC project and this action.
+- **Note:** OpenShift 4.15 is not supported due to known compatibility issues with modern runners and will be blocked by this action.
+
+For more details, see the [action.yml](action.yml) and workflow examples.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ with:
 ```
 
 - The default is `latest`, which will use the most recent supported version.  If you leave `desiredOCPVersion` blank, you will get the latest version.
-- Supported values are `4.14`, `4.16`, `4.17`, `4.18`, and any other version supported by the CRC project and this action.
-- **Note:** OpenShift 4.15 is not supported due to known compatibility issues with modern runners and will be blocked by this action.
+- Supported values are `4.17`, `4.18`, and `latest`.
 
 For more details, see the [action.yml](action.yml) and workflow examples.

--- a/action.yml
+++ b/action.yml
@@ -44,15 +44,16 @@ runs:
         if [ "${{ inputs.desiredOCPVersion }}" = "latest" ]; then
           echo "crc_version=latest" | tee "$GITHUB_OUTPUT"
         else
-          if [ "${{ inputs.desiredOCPVersion }}" = "4.15" ]; then
-            echo "[ERROR] OpenShift version 4.15 is not supported in this action due to known compatibility issues with modern runners." >&2
+          # Only allow OCP versions 4.17 and above
+          if [[ ! "${{ inputs.desiredOCPVersion }}" =~ ^4\.(1[7-9]|[2-9][0-9])$ ]] && [[ "${{ inputs.desiredOCPVersion }}" != "latest" ]]; then
+            echo "[ERROR] Only OpenShift versions 4.17 and above are supported in this action." >&2
             exit 1
           fi
           CRC_VERSION=$("${{ github.action_path }}/scripts/fetch-ocp-crc-version.sh" "${{ inputs.desiredOCPVersion }}")
           if [[ $CRC_VERSION == No* ]]; then
             echo "[ERROR] The requested OpenShift version (${{ inputs.desiredOCPVersion }}) is not supported or no matching CRC release was found." >&2
             echo "Details: $CRC_VERSION" >&2
-            echo "Please choose a supported OCP version (e.g., 4.10 or above, except 4.15) or check https://github.com/crc-org/crc/releases for available versions." >&2
+            echo "Please choose a supported OCP version (e.g., 4.17 or above) or check https://github.com/crc-org/crc/releases for available versions." >&2
             exit 1
           fi
           echo "crc_version=$CRC_VERSION" | tee "$GITHUB_OUTPUT"
@@ -241,6 +242,13 @@ runs:
       run: |
         sudo ${{ github.action_path }}/scripts/install-oc-tools.sh --latest ${{ steps.ocp_version_lookup.outputs.ocp_version }}
 
+    - name: Scale down OpenShift Console components to save CPU
+      shell: bash
+      run: |
+        oc scale --replicas=0 deployment.apps/console -n openshift-console || true
+        oc scale --replicas=0 deployment.apps/downloads -n openshift-console || true
+        oc scale --replicas=0 deployment.apps/console-operator -n openshift-console || true
+    
     - name: Wait until node is Ready state
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -28,14 +28,40 @@ inputs:
     description: 'Wait for all operators to be ready'
     required: false
     default: 'false'
+  desiredOCPVersion:
+    description: 'OpenShift version to deploy'
+    required: false
+    default: 'latest'
 
 runs:
   using: 'composite'
   steps:
+
+    - name: Set CRC version variable
+      id: set_crc_version
+      shell: bash
+      run: |
+        if [ "${{ inputs.desiredOCPVersion }}" = "latest" ]; then
+          echo "crc_version=latest" | tee "$GITHUB_OUTPUT"
+        else
+          if [ "${{ inputs.desiredOCPVersion }}" = "4.15" ]; then
+            echo "[ERROR] OpenShift version 4.15 is not supported in this action due to known compatibility issues with modern runners." >&2
+            exit 1
+          fi
+          CRC_VERSION=$("${{ github.action_path }}/scripts/fetch-ocp-crc-version.sh" "${{ inputs.desiredOCPVersion }}")
+          if [[ $CRC_VERSION == No* ]]; then
+            echo "[ERROR] The requested OpenShift version (${{ inputs.desiredOCPVersion }}) is not supported or no matching CRC release was found." >&2
+            echo "Details: $CRC_VERSION" >&2
+            echo "Please choose a supported OCP version (e.g., 4.10 or above, except 4.15) or check https://github.com/crc-org/crc/releases for available versions." >&2
+            exit 1
+          fi
+          echo "crc_version=$CRC_VERSION" | tee "$GITHUB_OUTPUT"
+        fi
+
     - name: Download and Install OpenShift Local Binary
       shell: bash
       run: |
-        curl -L -o crc.tar.xz https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/crc-linux-amd64.tar.xz
+        curl -L -o crc.tar.xz "https://mirror.openshift.com/pub/openshift-v4/clients/crc/${{ steps.set_crc_version.outputs.crc_version }}/crc-linux-amd64.tar.xz"
         tar -xvf crc.tar.xz
         sudo mv crc-linux-*/crc /usr/local/bin
 

--- a/scripts/fetch-ocp-crc-version.sh
+++ b/scripts/fetch-ocp-crc-version.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Fetch CRC releases and determine the latest release for each unique OpenShift major.minor version.
+
+GITHUB_API="https://api.github.com/repos/crc-org/crc/releases?per_page=100"
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <ocp_major.minor> (e.g., 4.18)" >&2
+  exit 1
+fi
+OCP_VERSION="$1"
+
+# Only support OCP versions 4.10 and above
+if ! [[ "$OCP_VERSION" =~ ^4\.([1-9][0-9]|10)$ ]]; then
+  echo "Error: Only OCP versions 4.10 and above are supported (e.g., 4.18, 4.20)." >&2
+  exit 2
+fi
+
+# Retry curl up to 10 times with 3s delay
+RETRIES=10
+for i in $(seq 1 $RETRIES); do
+  RESPONSE=$(curl -s "$GITHUB_API")
+  if [ -n "$RESPONSE" ] && [ "$RESPONSE" != "null" ]; then
+    break
+  fi
+  if [ "$i" -eq "$RETRIES" ]; then
+    echo "Error: Failed to fetch CRC releases from GitHub API after $RETRIES attempts." >&2
+    exit 3
+  fi
+  sleep 3
+done
+
+echo "$RESPONSE" | jq -r --arg OCP_MINOR "$OCP_VERSION" '
+  [
+    .[] 
+    | {
+        tag: .tag_name,
+        name: .name,
+        url: .html_url,
+        published: .published_at,
+        body: .body
+      }
+    | . + {
+        ocp_minor: (
+          if (.name | test("-[0-9]+\\.[0-9]+\\.[0-9]+$")) then
+            (.name | capture("-(?<ver>[0-9]+\\.[0-9]+)\\.[0-9]+$") | .ver)
+          elif (.body | test("OpenShift\\s+[0-9]+\\.[0-9]+\\.[0-9]+")) then
+            (.body | capture("OpenShift\\s+(?<ver>[0-9]+\\.[0-9]+)\\.[0-9]+") | .ver)
+          else
+            null
+          end
+        )
+      }
+    | select(.ocp_minor == $OCP_MINOR)
+  ]
+  | sort_by(.published)
+  | reverse
+  | .[0]
+  | if . == null then
+      ("No CRC release found for OpenShift version \($OCP_MINOR)")
+    else
+      (.tag | sub("^v"; ""))
+    end
+'


### PR DESCRIPTION
Users will now be able to choose a specific OCP version that they want by using the `defaultOCPVersion` variable.  The default is `latest`, but you should be able to select any version over 4.17 and above.  Future versions, such as 4.19 and 4.20 are not supported by CRC yet, and cannot be specified.

### OpenShift Version Selection and Validation:
* `.github/workflows/nightly.yml` and `.github/workflows/pre-main.yml`: Added a new matrix parameter `ocp` to support OpenShift versions `4.17`, `4.18`, and `latest`. Updated the workflows to pass the selected OpenShift version as the `desiredOCPVersion` input. [[1]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6R14) [[2]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6R33) [[3]](diffhunk://#diff-86d0e085d25794165165c5c4a8ada1e89ffa9d9e05724f710a26d5c2d28fb886R16) [[4]](diffhunk://#diff-86d0e085d25794165165c5c4a8ada1e89ffa9d9e05724f710a26d5c2d28fb886R35)
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R31-R65): Introduced a new input parameter `desiredOCPVersion` with validation logic to ensure only supported OpenShift versions (`4.17` and above) are deployed. Added logic to fetch the corresponding CRC version using the newly created script.

### Resource Optimization:
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R245-R251): Added steps to scale down OpenShift Console components to reduce CPU usage in the deployed environment.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R52): Added a section explaining how to select OpenShift versions using the `desiredOCPVersion` input variable, with examples and supported values.

### New Script for CRC Version Fetching:
* [`scripts/fetch-ocp-crc-version.sh`](diffhunk://#diff-9529ac2bc4e5fdb2585f25e48ecadafb4477c32047c0ed39eb7fefe2b26bb85fR1-R64): Created a script to fetch the latest CRC release for a given OpenShift version using the GitHub API, with error handling and validation for supported versions.