### PR TITLE
Add safety checks for deployments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -289,9 +289,27 @@ runs:
     - name: Scale down OpenShift Console components to save CPU
       shell: bash
       run: |
-        oc scale --replicas=0 deployment.apps/console -n openshift-console || true
-        oc scale --replicas=0 deployment.apps/downloads -n openshift-console || true
-        oc scale --replicas=0 deployment.apps/console-operator -n openshift-console || true
+        # Scale down console deployments if they exist
+        if oc get deployment.apps/console -n openshift-console &>/dev/null; then
+          oc scale --replicas=0 deployment.apps/console -n openshift-console || true
+        else
+          echo "console deployment not found in openshift-console namespace"
+        fi
+        
+        if oc get deployment.apps/downloads -n openshift-console &>/dev/null; then
+          oc scale --replicas=0 deployment.apps/downloads -n openshift-console || true
+        else
+          echo "downloads deployment not found in openshift-console namespace"
+        fi
+        
+        # Check for console-operator in multiple possible namespaces
+        if oc get deployment.apps/console-operator -n openshift-console &>/dev/null; then
+          oc scale --replicas=0 deployment.apps/console-operator -n openshift-console || true
+        elif oc get deployment.apps/console-operator -n openshift-console-operator &>/dev/null; then
+          oc scale --replicas=0 deployment.apps/console-operator -n openshift-console-operator || true
+        else
+          echo "console-operator deployment not found in openshift-console or openshift-console-operator namespaces"
+        fi
 
     - name: Set the adm policy
       shell: bash


### PR DESCRIPTION
To prevent printing errors, lets just do a check first if the deployments exist.