### PR TITLE
Bump disk size default to 31GB

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   crcDiskSize:
     description: 'Disk size for OpenShift Local'
     required: false
-    default: '35'
+    default: '31'
   bundleCache:
     description: 'Cache the crc bundles for faster startup'
     required: false


### PR DESCRIPTION
This pull request includes a small change to the `action.yml` file. The default value for the `crcDiskSize` input has been updated from `35` to `31` to reflect a new configuration.