### PR TITLE
Add explicit 4.19 testing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
-        ocp: [4.17, 4.18, latest]
+        ocp: [4.17, 4.18, 4.19, latest]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
-        ocp: [4.17, 4.18, latest]
+        ocp: [4.17, 4.18, 4.19, latest]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash


### PR DESCRIPTION
This pull request updates the OpenShift Container Platform (`ocp`) versions in the workflow configuration files to include version `4.19`. 

Workflow updates:

* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L14-R14): Added `4.19` to the `ocp` matrix in the nightly workflow configuration.
* [`.github/workflows/pre-main.yml`](diffhunk://#diff-86d0e085d25794165165c5c4a8ada1e89ffa9d9e05724f710a26d5c2d28fb886L16-R16): Added `4.19` to the `ocp` matrix in the pre-main workflow configuration.