### PR TITLE
Wait for Pods flag and logic

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,5 +31,7 @@ jobs:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           desiredOCPVersion: ${{ matrix.ocp }}
+          waitForPodsReady: true
+          waitForOperatorsReady: true
         env:
           OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -33,5 +33,7 @@ jobs:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           desiredOCPVersion: ${{ matrix.ocp }}
+          waitForPodsReady: true
+          waitForOperatorsReady: true
         env:
           OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Wait for all operators to be ready'
     required: false
     default: 'false'
+  waitForPodsReady:
+    description: 'Wait for all pods to be ready'
+    required: false
+    default: 'false'
   desiredOCPVersion:
     description: 'OpenShift version to deploy'
     required: false
@@ -440,6 +444,59 @@ runs:
       if: ${{ inputs.waitForOperatorsReady == 'true' }}
       shell: bash
       run: ${{ github.action_path }}/scripts/wait-for-operators.sh
+
+    - name: Wait for pods to be ready
+      if: ${{ inputs.waitForPodsReady == 'true' }}
+      shell: bash
+      run: |
+        echo "⏳ Waiting for pods to be ready (excluding scaled-down deployments)..."
+        
+        while true; do
+          # Get all pods that are not Running or Completed
+          PROBLEMATIC_PODS=$(oc get pods --all-namespaces --no-headers | grep -vE 'Running|Completed' | awk '{print $1":"$2}')
+          
+          if [ -z "$PROBLEMATIC_PODS" ]; then
+            echo "✅ All pods are Running or Completed."
+            break
+          fi
+          
+          # Filter out pods from deployments that have been scaled to 0
+          FILTERED_PODS=""
+          for pod_info in $PROBLEMATIC_PODS; do
+            namespace=$(echo $pod_info | cut -d: -f1)
+            pod_name=$(echo $pod_info | cut -d: -f2)
+            
+            # Check if this pod belongs to a deployment with 0 replicas
+            DEPLOYMENT_NAME=""
+            if [[ $pod_name == console-operator-* ]]; then
+              DEPLOYMENT_NAME="console-operator"
+            elif [[ $pod_name == console-* ]] && [[ $namespace == "openshift-console" ]]; then
+              DEPLOYMENT_NAME="console"
+            elif [[ $pod_name == downloads-* ]] && [[ $namespace == "openshift-console" ]]; then
+              DEPLOYMENT_NAME="downloads"
+            fi
+            
+            if [ -n "$DEPLOYMENT_NAME" ]; then
+              # Check if the deployment exists and has 0 replicas
+              REPLICAS=$(oc get deployment.apps/$DEPLOYMENT_NAME -n $namespace -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+              if [ "$REPLICAS" = "0" ]; then
+                echo "⏭️  Ignoring pod $pod_name in namespace $namespace (deployment scaled to 0)"
+                continue
+              fi
+            fi
+            
+            # If we get here, this pod is problematic and not from a scaled-down deployment
+            FILTERED_PODS="$FILTERED_PODS $pod_info"
+          done
+          
+          if [ -z "$FILTERED_PODS" ]; then
+            echo "✅ All pods are Running or Completed (ignoring scaled-down deployments)."
+            break
+          fi
+          
+          echo "⏳ Waiting for pods: $(echo $FILTERED_PODS | tr ' ' '\n' | cut -d: -f2 | tr '\n' ' ')"
+          sleep 5
+        done
 
     - name: Comprehensive Disk Space Report
       shell: bash


### PR DESCRIPTION
This pull request introduces enhancements to the CI workflows and configuration files to improve the readiness checks for OpenShift deployments. The changes add new options to wait for pods and operators to be ready before proceeding, ensuring more robust and reliable workflows.

### Workflow Enhancements:

* `.github/workflows/nightly.yml` and `.github/workflows/pre-main.yml`: Added `waitForPodsReady` and `waitForOperatorsReady` parameters to the jobs, enabling readiness checks for pods and operators during workflow execution. [[1]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6R34-R35) [[2]](diffhunk://#diff-86d0e085d25794165165c5c4a8ada1e89ffa9d9e05724f710a26d5c2d28fb886R36-R37)

### Configuration Updates:

* `action.yml`:
  * Added a new `waitForPodsReady` input with a description, default value, and optional requirement, allowing users to specify whether to wait for all pods to be ready.
  * Added a new step in the `runs` section to implement the `waitForPodsReady` functionality. This step uses a loop to check pod statuses and waits until all pods are in a `Running` or `Completed` state.