### PR TITLE
Remove 4.17 support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
-        ocp: [4.17, 4.18, 4.19, latest]
+        ocp: [4.18, 4.19, latest]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
-        ocp: [4.17, 4.18, 4.19, latest]
+        ocp: [4.18, 4.19, latest]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ with:
 ```
 
 - The default is `latest`, which will use the most recent supported version.  If you leave `desiredOCPVersion` blank, you will get the latest version.
-- Supported values are `4.17`, `4.18`, and `latest`.
+- Supported values are `4.18`, `4.19`, and `latest`.
 
 For more details, see the [action.yml](action.yml) and workflow examples.

--- a/action.yml
+++ b/action.yml
@@ -45,9 +45,9 @@ runs:
         if [ "${{ inputs.desiredOCPVersion }}" = "latest" ]; then
           echo "crc_version=latest" | tee "$GITHUB_OUTPUT"
         else
-          # Only allow OCP versions 4.17 and above
-          if [[ ! "${{ inputs.desiredOCPVersion }}" =~ ^4\.(1[7-9]|[2-9][0-9])$ ]] && [[ "${{ inputs.desiredOCPVersion }}" != "latest" ]]; then
-            echo "[ERROR] Only OpenShift versions 4.17 and above are supported in this action." >&2
+          # Only allow OCP versions 4.18 and above
+          if [[ ! "${{ inputs.desiredOCPVersion }}" =~ ^4\.(1[8-9]|[2-9][0-9])$ ]] && [[ "${{ inputs.desiredOCPVersion }}" != "latest" ]]; then
+            echo "[ERROR] Only OpenShift versions 4.18 and above are supported in this action." >&2
             exit 1
           fi
           echo "Fetching CRC version for OCP ${{ inputs.desiredOCPVersion }}..."
@@ -56,7 +56,7 @@ runs:
           if [[ $CRC_VERSION == No* ]] || [[ $CRC_VERSION == Error* ]]; then
             echo "[ERROR] The requested OpenShift version (${{ inputs.desiredOCPVersion }}) is not supported or no matching CRC release was found." >&2
             echo "Details: $CRC_VERSION" >&2
-            echo "Please choose a supported OCP version (e.g., 4.17 or above) or check https://github.com/crc-org/crc/releases for available versions." >&2
+            echo "Please choose a supported OCP version (e.g., 4.18 or above) or check https://github.com/crc-org/crc/releases for available versions." >&2
             exit 1
           fi
           # If script returns 'latest' due to API issues, use latest


### PR DESCRIPTION
4.17 was failing our nightlies for a few weeks now.  Let's just remove the support for it as I can no longer recommend people use that setting.

**OCP Version Support Updates:**

* Updated the OCP version matrix in `.github/workflows/nightly.yml` and `.github/workflows/pre-main.yml` to remove support for 4.17; now only 4.18, 4.19, and `latest` are supported. [[1]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L14-R14) [[2]](diffhunk://#diff-86d0e085d25794165165c5c4a8ada1e89ffa9d9e05724f710a26d5c2d28fb886L16-R16)
* Changed documentation in `README.md` to state that supported values for `desiredOCPVersion` are now `4.18`, `4.19`, and `latest`.

**Validation and Error Messaging:**

* Modified the input validation logic in `action.yml` to only allow OCP versions 4.18 and above, updating regex checks and error messages accordingly.
* Updated error messaging in `action.yml` to instruct users to choose OCP 4.18 or above if an unsupported version is requested.