### PR TITLE
Adjust swap to avoid OOM

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,28 @@ runs:
         ls -la /home/runner/.crc/
         df -h
 
+    - name: Create swap on /mnt to reduce OOM risk
+      shell: bash
+      run: |
+        echo "=== Ensuring swap exists on /mnt ==="
+        SWAPFILE="/mnt/swapfile"
+        # Create a ~8G swapfile if no swap is active
+        if ! sudo swapon --show | grep -q "."; then
+          echo "No active swap detected; creating ${SWAPFILE}"
+          sudo fallocate -l 8G "$SWAPFILE" || sudo dd if=/dev/zero of="$SWAPFILE" bs=1M count=8192
+          sudo chmod 600 "$SWAPFILE"
+          sudo mkswap "$SWAPFILE"
+          sudo swapon "$SWAPFILE"
+        else
+          echo "Swap already active; skipping creation"
+        fi
+        # Prefer swap usage slightly to avoid OOM on transient spikes
+        if [ -w /proc/sys/vm/swappiness ]; then
+          echo 80 | sudo tee /proc/sys/vm/swappiness
+        fi
+        echo "=== Active swap devices ==="
+        sudo swapon --show || true
+
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
@@ -163,7 +185,7 @@ runs:
         dotnet: true
         haskell: true
         docker-images: true
-        swap-storage: true
+        swap-storage: false
       continue-on-error: true
 
     - name: Install dependencies for specific Ubuntu versions
@@ -302,6 +324,39 @@ runs:
         
         echo "=== Disk usage after CRC start ==="
         df -h
+
+    - name: Protect CRC/QEMU from OOM killer
+      shell: bash
+      run: |
+        echo "=== Applying OOM protection for CRC/QEMU ==="
+        # Find qemu/kvm processes for the CRC VM and decrease their OOM killer score
+        for pid in $(pgrep -f "qemu-system-x86_64|qemu-kvm" || true); do
+          if [ -w "/proc/$pid/oom_score_adj" ]; then
+            # -1000 is fully immune; use -500 to reduce risk while staying fair
+            echo -500 | sudo tee "/proc/$pid/oom_score_adj" || true
+            echo "Adjusted oom_score_adj for PID $pid"
+          fi
+        done
+        # Also protect the crc helper process if present
+        for pid in $(pgrep -f "^crc .*start|crc-driver" || true); do
+          if [ -w "/proc/$pid/oom_score_adj" ]; then
+            echo -500 | sudo tee "/proc/$pid/oom_score_adj" || true
+            echo "Adjusted oom_score_adj for CRC PID $pid"
+          fi
+        done
+
+        # Lightweight watchdog to periodically re-apply in case of restarts
+        ( while true; do
+            for pid in $(pgrep -f "qemu-system-x86_64|qemu-kvm" || true); do
+              if [ -w "/proc/$pid/oom_score_adj" ]; then
+                CURRENT=$(cat "/proc/$pid/oom_score_adj" || echo 0)
+                if [ "$CURRENT" -gt -500 ]; then
+                  echo -500 | sudo tee "/proc/$pid/oom_score_adj" >/dev/null 2>&1 || true
+                fi
+              fi
+            done
+            sleep 15
+          done ) >/dev/null 2>&1 &
 
     - name: Move the .crcbundle files to another temporary folder
       shell: bash


### PR DESCRIPTION
This pull request adds new steps to the `action.yml` workflow to reduce the risk of out-of-memory (OOM) errors during CI runs, specifically targeting CRC/QEMU processes. It introduces swap space creation and OOM killer protection mechanisms, and disables the `swap-storage` option in the disk space freeing step to avoid interference with the new swap setup.

**Memory management improvements:**

* Added a step to create an 8GB swap file on `/mnt` if no swap is active, and increased system swappiness to prefer swap usage, helping to reduce OOM risk during heavy memory usage.
* Disabled the `swap-storage` option in the `jlumbroso/free-disk-space` step to prevent it from deleting the newly created swap file.

**OOM killer protection:**

* Introduced a step to lower the OOM killer score for CRC/QEMU and related processes, making them less likely to be terminated during memory pressure. Includes a lightweight watchdog to periodically re-apply the protection for new/restarted processes.