### PR TITLE
Add apt-get update to ubuntu 22.04

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,6 +195,7 @@ runs:
         echo "Detected Ubuntu version: $UBUNTU_VERSION"
         if [[ "$UBUNTU_VERSION" == "22.04" ]]; then
           echo "Installing specific dependencies for Ubuntu 22.04"
+          sudo apt-get update
           sudo apt-get install -y qemu
         elif [[ "$UBUNTU_VERSION" == "24.04" ]]; then
           echo "Installing specific dependencies for Ubuntu 24.04"


### PR DESCRIPTION
These nightlies have been failing with a weird new error:

```
The following NEW packages will be installed:
  qemu
0 upgraded, 1 newly installed, 0 to remove and 15 not upgraded.
Need to get 13.7 kB of archives.
After this operation, 142 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu amd64 1:6.2+dfsg-2ubuntu6.26
Ign:2 https://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu amd64 1:6.2+dfsg-2ubuntu6.26
Err:2 https://security.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu amd64 1:6.2+dfsg-2ubuntu6.26
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu_6.2%2bdfsg-2ubuntu6.26_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

https://github.com/rh-ecosystem-edge/eco-goinfra/actions/runs/17719723206/job/50349797998
https://github.com/palmsoftware/quick-ocp/actions/runs/17704939961/job/50315458340