### PR TITLE
Add retries for tarball download

### DIFF
--- a/scripts/download-install-crc.sh
+++ b/scripts/download-install-crc.sh
@@ -3,7 +3,43 @@ set -e
 
 CRC_VERSION="$1"
 
-curl -L -o crc.tar.xz "https://mirror.openshift.com/pub/openshift-v4/clients/crc/$CRC_VERSION/crc-linux-amd64.tar.xz"
+# Retry logic for downloading CRC
+MAX_RETRIES=3
+RETRY_COUNT=0
+DOWNLOAD_SUCCESS=false
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES: Downloading CRC version $CRC_VERSION..."
+
+  # Remove any partial download from previous attempt
+  rm -f crc.tar.xz
+
+  if curl -L -o crc.tar.xz "https://mirror.openshift.com/pub/openshift-v4/clients/crc/$CRC_VERSION/crc-linux-amd64.tar.xz"; then
+    # Verify the downloaded file is valid (should be larger than 1MB)
+    FILE_SIZE=$(stat -c%s crc.tar.xz 2>/dev/null || stat -f%z crc.tar.xz 2>/dev/null || echo 0)
+    if [ "$FILE_SIZE" -gt 1048576 ]; then
+      echo "Download successful. File size: $FILE_SIZE bytes"
+      DOWNLOAD_SUCCESS=true
+      break
+    else
+      echo "Download failed: File too small ($FILE_SIZE bytes), likely an error page"
+    fi
+  else
+    echo "Download failed with curl error"
+  fi
+
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+    echo "Waiting 10 seconds before retry..."
+    sleep 10
+  fi
+done
+
+if [ "$DOWNLOAD_SUCCESS" = false ]; then
+  echo "Failed to download CRC after $MAX_RETRIES attempts"
+  exit 1
+fi
+
 tar -xvf crc.tar.xz
 if [ -d crc-linux-* ] && [ -f crc-linux-*/crc ]; then
   sudo mv crc-linux-*/crc /usr/local/bin


### PR DESCRIPTION
This pull request enhances the reliability of the CRC (CodeReady Containers) download process in the `scripts/download-install-crc.sh` script by introducing retry logic and file validation. The script now attempts to download the CRC archive multiple times and verifies the integrity of the downloaded file before proceeding with extraction and installation.

Improvements to download reliability:

* Added a retry loop that attempts to download the CRC archive up to three times, with a 10-second wait between attempts if a download fails.
* Implemented file validation to ensure the downloaded file is larger than 1MB, reducing the risk of processing incomplete or erroneous downloads (such as HTML error pages).
* The script now exits with an error if all download attempts fail, preventing further steps from running with an invalid or missing file.