### PR TITLE
Suppress deprecated nodeSelector warnings

### DIFF
--- a/scripts/scale-down-console.sh
+++ b/scripts/scale-down-console.sh
@@ -5,14 +5,14 @@ echo "=== Scaling down non-essential OpenShift components ==="
 
 # Scale down console deployments if they exist
 if oc get deployment.apps/console -n openshift-console &>/dev/null; then
-  oc scale --replicas=0 deployment.apps/console -n openshift-console || true
+  oc scale --replicas=0 deployment.apps/console -n openshift-console 2>&1 | grep -v "node-role.kubernetes.io/master" || true
   echo "Scaled down console deployment"
 else
   echo "console deployment not found in openshift-console namespace"
 fi
 
 if oc get deployment.apps/downloads -n openshift-console &>/dev/null; then
-  oc scale --replicas=0 deployment.apps/downloads -n openshift-console || true
+  oc scale --replicas=0 deployment.apps/downloads -n openshift-console 2>&1 | grep -v "node-role.kubernetes.io/master" || true
   echo "Scaled down downloads deployment"
 else
   echo "downloads deployment not found in openshift-console namespace"
@@ -20,10 +20,10 @@ fi
 
 # Check for console-operator in multiple possible namespaces
 if oc get deployment.apps/console-operator -n openshift-console &>/dev/null; then
-  oc scale --replicas=0 deployment.apps/console-operator -n openshift-console || true
+  oc scale --replicas=0 deployment.apps/console-operator -n openshift-console 2>&1 | grep -v "node-role.kubernetes.io/master" || true
   echo "Scaled down console-operator in openshift-console"
 elif oc get deployment.apps/console-operator -n openshift-console-operator &>/dev/null; then
-  oc scale --replicas=0 deployment.apps/console-operator -n openshift-console-operator || true
+  oc scale --replicas=0 deployment.apps/console-operator -n openshift-console-operator 2>&1 | grep -v "node-role.kubernetes.io/master" || true
   echo "Scaled down console-operator in openshift-console-operator"
 else
   echo "console-operator deployment not found in openshift-console or openshift-console-operator namespaces"


### PR DESCRIPTION
## Summary
- Filter out `node-role.kubernetes.io/master` deprecation warnings from console scaling operations
- Reduces noise in CI logs while preserving actual error output

## Details
OpenShift console deployments still use the deprecated `node-role.kubernetes.io/master` nodeSelector label internally. When running `oc scale` commands, this generates harmless warnings that clutter the output:

```
Warning: spec.template.spec.nodeSelector[node-role.kubernetes.io/master]: use "node-role.kubernetes.io/control-plane" instead
```

This PR filters these warnings using `grep -v` while maintaining the existing error handling and success messages.

## Test plan
- [x] Verified change locally
- [ ] CI will validate the script runs without errors
- [ ] Warnings should no longer appear in downstream workflows using quick-ocp