### PR TITLE
feat: add preloadImages input for mirroring container images into cluster

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: check if OCP_PULL_SECRET exists
-        env: 
+        env:
           super_secret: ${{ secrets.OCP_PULL_SECRET }}
         if: ${{ env.super_secret == '' }}
         run: 'echo the secret \"OCP_PULL_SECRET\" has not been made; echo please go to \"settings \> secrets \> actions\" to create it'
@@ -51,3 +51,32 @@ jobs:
           desiredOCPVersion: ${{ matrix.ocp }}
         env:
           OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
+
+  test-preload-images:
+    # Skip for Dependabot PRs - secrets are not available
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    env:
+      SHELL: /bin/bash
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v6
+
+      - name: Deploy OCP with preloaded images
+        uses: ./
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+          desiredOCPVersion: 'latest'
+          preloadImages: |
+            docker.io/library/nginx:latest
+        env:
+          OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
+
+      - name: Verify preloaded image exists as imagestream
+        run: |
+          echo "=== Checking for preloaded imagestream ==="
+          oc get imagestream nginx -n openshift -o jsonpath='{.metadata.name}'
+          echo ""
+          echo "=== Imagestream details ==="
+          oc get imagestream nginx -n openshift -o yaml

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Disable the connectivity check for OpenShift Mirror'
     required: false
     default: 'false'
+  preloadImages:
+    description: 'Newline-separated list of container images to preload into the cluster registry'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -164,6 +168,11 @@ runs:
     - name: Set the adm policy
       shell: bash
       run: ${{ github.action_path }}/scripts/set-adm-policy.sh
+
+    - name: Preload container images into cluster registry
+      if: ${{ inputs.preloadImages != '' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/preload-images.sh "${{ inputs.preloadImages }}"
 
     - name: Wait for operators to be available
       if: ${{ inputs.waitForOperatorsReady == 'true' }}

--- a/scripts/preload-images.sh
+++ b/scripts/preload-images.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+IMAGE_LIST="$1"
+
+if [ -z "$IMAGE_LIST" ]; then
+  echo "No images to preload"
+  exit 0
+fi
+
+echo "=== Preloading container images into cluster registry ==="
+
+# Enable the default route on the image registry
+echo "Enabling default route on image registry..."
+oc patch configs.imageregistry.operator.openshift.io/cluster \
+  --type merge \
+  -p '{"spec":{"defaultRoute":true}}'
+
+# Wait for the route to appear
+echo "Waiting for image registry route..."
+timeout=120
+elapsed=0
+while ! oc get route default-route -n openshift-image-registry &>/dev/null; do
+  sleep 5
+  elapsed=$((elapsed + 5))
+  if [ $elapsed -ge $timeout ]; then
+    echo "ERROR: Timed out waiting for image registry route after ${timeout}s"
+    exit 1
+  fi
+done
+
+# Get the registry hostname
+REGISTRY=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
+echo "Registry hostname: $REGISTRY"
+
+# Get the kubeadmin token
+TOKEN=$(oc whoami -t)
+
+# Login to the registry with podman
+echo "Logging into cluster registry..."
+podman login "$REGISTRY" \
+  --username kubeadmin \
+  --password "$TOKEN" \
+  --tls-verify=false
+
+# Parse and mirror each image
+SUCCESS=0
+FAILED=0
+FAILED_IMAGES=""
+
+while IFS= read -r IMAGE; do
+  # Skip empty lines and comments
+  IMAGE=$(echo "$IMAGE" | xargs)
+  if [ -z "$IMAGE" ] || [[ "$IMAGE" == \#* ]]; then
+    continue
+  fi
+
+  # Derive the image name for the registry
+  # e.g., docker.io/library/nginx:latest -> nginx:latest
+  # e.g., quay.io/myorg/myapp:v1 -> myapp:v1
+  IMAGE_NAME=$(echo "$IMAGE" | rev | cut -d'/' -f1 | rev)
+
+  echo "--- Mirroring: $IMAGE -> $REGISTRY/openshift/$IMAGE_NAME ---"
+
+  if oc image mirror \
+    "$IMAGE" \
+    "$REGISTRY/openshift/$IMAGE_NAME" \
+    --insecure=true \
+    --keep-manifest-list=true 2>&1; then
+    echo "OK: $IMAGE"
+    SUCCESS=$((SUCCESS + 1))
+  else
+    echo "FAILED: $IMAGE"
+    FAILED=$((FAILED + 1))
+    FAILED_IMAGES="$FAILED_IMAGES  - $IMAGE\n"
+  fi
+done <<<"$IMAGE_LIST"
+
+echo ""
+echo "=== Image preload summary ==="
+echo "Succeeded: $SUCCESS"
+echo "Failed: $FAILED"
+if [ $FAILED -gt 0 ]; then
+  echo "Failed images:"
+  echo -e "$FAILED_IMAGES"
+  exit 1
+fi
+echo "=== Image preload complete ==="


### PR DESCRIPTION
## Summary

- Adds `preloadImages` input that accepts a newline-separated list of container images to preload into the cluster's internal OpenShift registry
- New `scripts/preload-images.sh` enables the registry default route, authenticates via kubeadmin token, and uses `oc image mirror` to push images into the `openshift` namespace as cluster-wide imagestreams
- Adds a `test-preload-images` CI job that deploys a cluster with `nginx:latest` preloaded and verifies the imagestream exists

This provides the same functionality proposed in [crc-org/crc#5188](https://github.com/crc-org/crc/pull/5188) but at the action level, so it works regardless of upstream adoption.

### Usage

```yaml
- uses: palmsoftware/quick-ocp@v0
  with:
    ocpPullSecret: $OCP_PULL_SECRET
    preloadImages: |
      docker.io/library/nginx:latest
      docker.io/library/busybox:latest
  env:
    OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
```

## Test plan

- [ ] `make lint` passes
- [ ] `test-preload-images` job deploys cluster, preloads nginx, and verifies imagestream exists
- [ ] Existing `run-ocp` matrix jobs unaffected (preloadImages defaults to empty)