### PR TITLE
Add Red Hat status pre-flight check

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,12 @@ jobs:
     env:
       SHELL: /bin/bash
     steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            Red Hat OpenShift Cluster Manager
+
       - name: Checkout the code
         uses: actions/checkout@v6
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,8 @@ jobs:
         uses: palmsoftware/redhat-status@v0
         with:
           components: |
-            Red Hat OpenShift Cluster Manager
+            api.openshift.com
+            developers.redhat.com
 
       - name: Checkout the code
         uses: actions/checkout@v6

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -38,7 +38,8 @@ jobs:
         uses: palmsoftware/redhat-status@v0
         with:
           components: |
-            Red Hat OpenShift Cluster Manager
+            api.openshift.com
+            developers.redhat.com
 
       - name: Checkout the code
         uses: actions/checkout@v6

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -34,6 +34,12 @@ jobs:
     env:
       SHELL: /bin/bash
     steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            Red Hat OpenShift Cluster Manager
+
       - name: Checkout the code
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Add [`palmsoftware/redhat-status`](https://github.com/palmsoftware/redhat-status)`@v0` as first step in `run-ocp` jobs in both pre-main and nightly workflows
- Filters to `Red Hat OpenShift Cluster Manager` component group (covers mirror.openshift.com and CRC infrastructure)
- Informational only — prints status but does not fail the workflow
- Provides early visibility when Red Hat infrastructure issues may cause CRC provisioning failures

## Related
- palmsoftware/quick-k8s#105