### PR TITLE
feat: add enableClusterMonitoring input

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -59,6 +59,42 @@ jobs:
         env:
           OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
 
+  test-cluster-monitoring:
+    # Skip for Dependabot PRs - secrets are not available
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    env:
+      SHELL: /bin/bash
+    steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            api.openshift.com
+            developers.redhat.com
+
+      - name: Checkout the code
+        uses: actions/checkout@v6
+
+      - name: Deploy OCP with cluster monitoring enabled
+        uses: ./
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+          desiredOCPVersion: 'latest'
+          crcMemory: '14336'
+          enableClusterMonitoring: true
+        env:
+          OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
+
+      - name: Verify monitoring stack is running
+        run: |
+          echo "=== Checking cluster monitoring pods ==="
+          oc get pods -n openshift-monitoring
+          echo "=== Verifying prometheus-k8s is running ==="
+          oc wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n openshift-monitoring --timeout=300s
+          echo "=== Cluster monitoring is operational ==="
+
   test-preload-images:
     # Skip for Dependabot PRs - secrets are not available
     if: github.actor != 'dependabot[bot]'

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Disable the connectivity check for OpenShift Mirror'
     required: false
     default: 'false'
+  enableClusterMonitoring:
+    description: 'Enable the cluster monitoring stack (requires minimum 14GiB memory)'
+    required: false
+    default: 'false'
   preloadImages:
     description: 'Newline-separated list of container images to preload into the cluster registry'
     required: false
@@ -124,7 +128,7 @@ runs:
 
     - name: Start OpenShift Local
       shell: bash
-      run: ${{ github.action_path }}/scripts/configure-crc.sh "${{ inputs.crcCpu }}" "${{ inputs.crcMemory }}" "${{ inputs.crcDiskSize }}" "${{ inputs.enableTelemetry }}"
+      run: ${{ github.action_path }}/scripts/configure-crc.sh "${{ inputs.crcCpu }}" "${{ inputs.crcMemory }}" "${{ inputs.crcDiskSize }}" "${{ inputs.enableTelemetry }}" "${{ inputs.enableClusterMonitoring }}"
 
     - name: Run setup
       shell: bash

--- a/scripts/configure-crc.sh
+++ b/scripts/configure-crc.sh
@@ -5,6 +5,16 @@ CRC_CPU="$1"
 CRC_MEMORY="$2"
 CRC_DISK_SIZE="$3"
 ENABLE_TELEMETRY="$4"
+ENABLE_CLUSTER_MONITORING="$5"
+
+MIN_MONITORING_MEMORY=14336
+
+if [ "$ENABLE_CLUSTER_MONITORING" = "true" ]; then
+  if [ "$CRC_MEMORY" -lt "$MIN_MONITORING_MEMORY" ]; then
+    echo "=== Cluster monitoring requires ${MIN_MONITORING_MEMORY}MB memory, increasing from ${CRC_MEMORY}MB ==="
+    CRC_MEMORY=$MIN_MONITORING_MEMORY
+  fi
+fi
 
 echo "=== Configuring CRC for minimal resource usage ==="
 crc config set cpus $CRC_CPU
@@ -12,3 +22,8 @@ crc config set memory $CRC_MEMORY
 crc config set disk-size $CRC_DISK_SIZE
 crc config set consent-telemetry $ENABLE_TELEMETRY
 crc config set network-mode user
+
+if [ "$ENABLE_CLUSTER_MONITORING" = "true" ]; then
+  echo "=== Enabling cluster monitoring stack ==="
+  crc config set enable-cluster-monitoring true
+fi


### PR DESCRIPTION
## Summary
- Adds `enableClusterMonitoring` boolean input (default `false`) to optionally enable the CRC cluster monitoring stack (Prometheus, Alertmanager, etc.)
- When enabled, sets `crc config set enable-cluster-monitoring true` before `crc start`
- Requires minimum 14GiB memory; once enabled it cannot be disabled

## Test plan
- [x] Verify default behavior unchanged (monitoring remains disabled when input omitted)
- [x] Test with `enableClusterMonitoring: true` and `crcMemory: 14336` to confirm monitoring pods come up
- [x] Confirm `make lint` passes