### PR TITLE
fix: retry crc start on kubeconfig update failure

### DIFF
--- a/scripts/run-crc-setup.sh
+++ b/scripts/run-crc-setup.sh
@@ -8,7 +8,31 @@ echo "=== Disk usage after CRC setup ==="
 df -h
 
 echo "=== Starting CRC ==="
-sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug
+max_attempts=3
+attempt=1
+
+while [ $attempt -le $max_attempts ]; do
+  echo "=== CRC start attempt $attempt of $max_attempts ==="
+
+  start_output=$(sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug 2>&1) || true
+  echo "$start_output"
+
+  if echo "$start_output" | grep -q "Cannot update kubeconfig"; then
+    echo "WARNING: kubeconfig update failed during CRC start"
+    if [ $attempt -lt $max_attempts ]; then
+      echo "Stopping CRC and retrying..."
+      sudo -su $USER crc stop || true
+      sleep 10
+      attempt=$((attempt + 1))
+      continue
+    else
+      echo "ERROR: All $max_attempts attempts failed with kubeconfig error"
+      exit 1
+    fi
+  fi
+
+  break
+done
 
 # Clean up pull secret immediately after use
 rm -f pull-secret.json


### PR DESCRIPTION
## Summary

- CRC occasionally reports `Cannot update kubeconfig: connection reset by peer` during startup, then claims the cluster started successfully -- but `oc` cannot connect, causing `wait-for-node-ready.sh` to time out after 10 minutes
- This has been the sole cause of nightly flakiness over the past month, hitting OCP 4.18 in ~40% of runs
- Detect the error from `crc start` output and retry up to 3 times with `crc stop` in between -- restarts are fast since the bundle is already extracted

## Test plan

- [ ] Pre-main CI passes (linting)
- [ ] Trigger a manual nightly run to validate against OCP 4.18
- [ ] Monitor nightly results over the next few days for improved stability