### PR TITLE
fix: match actual CRC error message for kubeconfig retry

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -91,7 +91,9 @@ jobs:
         run: |
           echo "=== Checking cluster monitoring pods ==="
           oc get pods -n openshift-monitoring
-          echo "=== Verifying prometheus-k8s is running ==="
+          echo "=== Waiting for prometheus-k8s pod to be created ==="
+          oc wait --for=create pod -l app.kubernetes.io/name=prometheus -n openshift-monitoring --timeout=300s
+          echo "=== Waiting for prometheus-k8s pod to be Ready ==="
           oc wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n openshift-monitoring --timeout=300s
           echo "=== Cluster monitoring is operational ==="
 

--- a/scripts/run-crc-setup.sh
+++ b/scripts/run-crc-setup.sh
@@ -17,7 +17,7 @@ while [ $attempt -le $max_attempts ]; do
   start_output=$(sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug 2>&1) || true
   echo "$start_output"
 
-  if echo "$start_output" | grep -q "Cannot update kubeconfig"; then
+  if echo "$start_output" | grep -qi "failed to update kubeconfig\|cannot update kubeconfig"; then
     echo "WARNING: kubeconfig update failed during CRC start"
     if [ $attempt -lt $max_attempts ]; then
       echo "Stopping CRC and retrying..."


### PR DESCRIPTION
## Summary
- The retry logic in `run-crc-setup.sh` grepped for `"Cannot update kubeconfig"` but CRC 2.54.0 emits `"Failed to update kubeconfig file"` when the kubeconfig update fails
- This mismatch prevented retries from triggering, leaving the cluster API unreachable and causing `wait-for-node-ready.sh` to time out after 600s
- Broadened the grep to case-insensitively match both `"failed to update kubeconfig"` and `"cannot update kubeconfig"`

Fixes nightly failure: https://github.com/palmsoftware/quick-ocp/actions/runs/27083041919

## Test plan
- [ ] Verify nightly CI passes on next run
- [ ] Confirm retry triggers correctly when kubeconfig update fails (visible in logs as "WARNING: kubeconfig update failed during CRC start")