### PR TITLE
fix: normalize enableTelemetry input to true/false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   enableTelemetry:
     description: 'Enable telemetry for OpenShift Local'
     required: false
-    default: 'yes'
+    default: 'true'
   crcDiskSize:
     description: 'Disk size for OpenShift Local'
     required: false

--- a/scripts/configure-crc.sh
+++ b/scripts/configure-crc.sh
@@ -20,7 +20,14 @@ echo "=== Configuring CRC for minimal resource usage ==="
 crc config set cpus $CRC_CPU
 crc config set memory $CRC_MEMORY
 crc config set disk-size $CRC_DISK_SIZE
-crc config set consent-telemetry $ENABLE_TELEMETRY
+if [ "$ENABLE_TELEMETRY" = "true" ]; then
+  crc config set consent-telemetry yes
+elif [ "$ENABLE_TELEMETRY" = "false" ]; then
+  crc config set consent-telemetry no
+else
+  echo "WARNING: enableTelemetry='$ENABLE_TELEMETRY' is not 'true' or 'false', treating as false"
+  crc config set consent-telemetry no
+fi
 crc config set network-mode user
 
 if [ "$ENABLE_CLUSTER_MONITORING" = "true" ]; then


### PR DESCRIPTION
## Summary

- Changes `enableTelemetry` default from `yes` to `true`, consistent with every other boolean input (`bundleCache`, `waitForOperatorsReady`, `disableConnectivityCheck`, `enableClusterMonitoring`)
- Translates `true`/`false` to `yes`/`no` in `configure-crc.sh` before passing to CRC's `consent-telemetry` config
- Adds a warning message when unrecognized values are passed, helping users who may have explicitly set the old `yes`/`no` format

## Test plan

- [ ] CI passes with the new default (`true` -> CRC gets `yes`)
- [ ] Verify warning message appears when passing unexpected values like `yes` or `no`