### PR TITLE
fix: replace hardcoded /home/runner paths with $HOME/$USER

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
       if: ${{ inputs.bundleCache == 'true' }}
       id: restore-cache
       with:
-        path: /home/runner/.crc/bundletmp
+        path: ~/.crc/bundletmp
         key: ${{ runner.os }}-${{ runner.arch }}-crc-cache-${{ steps.crc_version_lookup.outputs.version_number }}
 
     - name: Copy the bundletmp to actual folder if cache hit
@@ -146,14 +146,14 @@ runs:
       uses: actions/cache/save@v5
       if: ${{ inputs.bundleCache == 'true' && steps.restore-cache.outputs.cache-hit != 'true' }}
       with:
-        path: /home/runner/.crc/bundletmp
+        path: ~/.crc/bundletmp
         key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
     - name: Cleanup CRC bundle temp files
       shell: bash
       run: |
         echo "=== Cleaning up CRC bundle temp files ==="
-        rm -rf /home/runner/.crc/bundletmp
+        rm -rf ~/.crc/bundletmp
         echo "=== Cleanup complete ==="
       continue-on-error: true
 

--- a/scripts/comprehensive-disk-report.sh
+++ b/scripts/comprehensive-disk-report.sh
@@ -20,11 +20,11 @@ sudo du -h --max-depth=2 / 2>/dev/null | grep -E '^[0-9.]+[GM]' | sort -hr | hea
 
 echo ""
 echo "=== CRC-Specific Disk Usage ==="
-if [ -d "/home/runner/.crc" ]; then
+if [ -d "$HOME/.crc" ]; then
   echo "CRC home directory:"
-  du -sh /home/runner/.crc/ 2>/dev/null || echo "Could not analyze CRC home directory"
+  du -sh "$HOME/.crc/" 2>/dev/null || echo "Could not analyze CRC home directory"
   echo "CRC symlinks:"
-  ls -la /home/runner/.crc/ 2>/dev/null || echo "Could not list CRC directory"
+  ls -la "$HOME/.crc/" 2>/dev/null || echo "Could not list CRC directory"
 fi
 
 if [ -d "/mnt/crc-cache" ]; then

--- a/scripts/copy-bundletmp-to-cache.sh
+++ b/scripts/copy-bundletmp-to-cache.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-mkdir -p /home/runner/.crc/cache
-if [ -d "/home/runner/.crc/bundletmp" ] && [ "$(ls -A /home/runner/.crc/bundletmp 2>/dev/null)" ]; then
-  cp -r /home/runner/.crc/bundletmp/* /home/runner/.crc/cache/
+mkdir -p "$HOME/.crc/cache"
+if [ -d "$HOME/.crc/bundletmp" ] && [ "$(ls -A "$HOME/.crc/bundletmp" 2>/dev/null)" ]; then
+  cp -r "$HOME/.crc/bundletmp"/* "$HOME/.crc/cache/"
 else
   echo "No files found in bundletmp to copy or directory does not exist"
 fi

--- a/scripts/move-crc-bundles-to-temp.sh
+++ b/scripts/move-crc-bundles-to-temp.sh
@@ -2,10 +2,10 @@
 set -e
 
 echo "=== Moving CRC bundles for caching ==="
-mkdir -p /home/runner/.crc/bundletmp
-if [ -n "$(ls /home/runner/.crc/cache/*.crcbundle 2>/dev/null)" ]; then
-  mv /home/runner/.crc/cache/*.crcbundle /home/runner/.crc/bundletmp/
-  echo "Moved $(ls /home/runner/.crc/bundletmp/*.crcbundle | wc -l) bundle files"
+mkdir -p "$HOME/.crc/bundletmp"
+if [ -n "$(ls "$HOME/.crc/cache"/*.crcbundle 2>/dev/null)" ]; then
+  mv "$HOME/.crc/cache"/*.crcbundle "$HOME/.crc/bundletmp/"
+  echo "Moved $(ls "$HOME/.crc/bundletmp"/*.crcbundle | wc -l) bundle files"
 else
   echo "No .crcbundle files found to move"
 fi

--- a/scripts/setup-crc-cache-larger-disk.sh
+++ b/scripts/setup-crc-cache-larger-disk.sh
@@ -4,30 +4,30 @@ set -e
 echo "=== Setting up CRC cache on larger disk partition ==="
 # Create CRC cache directory on /mnt (larger disk)
 sudo mkdir -p /mnt/crc-cache
-sudo chown -R runner:runner /mnt/crc-cache
+sudo chown -R "$USER:$USER" /mnt/crc-cache
 
 # Create symlink from default CRC cache location to /mnt
-mkdir -p /home/runner/.crc
-if [ ! -L "/home/runner/.crc/cache" ]; then
+mkdir -p "$HOME/.crc"
+if [ ! -L "$HOME/.crc/cache" ]; then
   # If cache directory exists, move it first
-  if [ -d "/home/runner/.crc/cache" ]; then
-    mv /home/runner/.crc/cache/* /mnt/crc-cache/ 2>/dev/null || true
-    rm -rf /home/runner/.crc/cache
+  if [ -d "$HOME/.crc/cache" ]; then
+    mv "$HOME/.crc/cache"/* /mnt/crc-cache/ 2>/dev/null || true
+    rm -rf "$HOME/.crc/cache"
   fi
-  ln -sf /mnt/crc-cache /home/runner/.crc/cache
+  ln -sf /mnt/crc-cache "$HOME/.crc/cache"
 fi
 
 # Also setup the machines directory on larger disk
 sudo mkdir -p /mnt/crc-machines
-sudo chown -R runner:runner /mnt/crc-machines
-if [ ! -L "/home/runner/.crc/machines" ]; then
-  if [ -d "/home/runner/.crc/machines" ]; then
-    mv /home/runner/.crc/machines/* /mnt/crc-machines/ 2>/dev/null || true
-    rm -rf /home/runner/.crc/machines
+sudo chown -R "$USER:$USER" /mnt/crc-machines
+if [ ! -L "$HOME/.crc/machines" ]; then
+  if [ -d "$HOME/.crc/machines" ]; then
+    mv "$HOME/.crc/machines"/* /mnt/crc-machines/ 2>/dev/null || true
+    rm -rf "$HOME/.crc/machines"
   fi
-  ln -sf /mnt/crc-machines /home/runner/.crc/machines
+  ln -sf /mnt/crc-machines "$HOME/.crc/machines"
 fi
 
 echo "=== CRC directories moved to larger disk ==="
-ls -la /home/runner/.crc/
+ls -la "$HOME/.crc/"
 df -h


### PR DESCRIPTION
## Summary

- Replace all hardcoded `/home/runner` paths with `$HOME` in 4 shell scripts
- Replace `runner:runner` with `$USER:$USER` in `chown` calls in `setup-crc-cache-larger-disk.sh`
- Replace `/home/runner/.crc/bundletmp` with `~/.crc/bundletmp` in `actions/cache` path fields in `action.yml`

This enables the action to work on self-hosted runners with non-default usernames and home directories.

## Test plan

- [ ] CI passes — all OCP deploy jobs use the correct paths
- [ ] Verify `grep -rn '/home/runner' scripts/ action.yml` returns zero results