### PR TITLE
feat: add action outputs for cluster credentials and versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,23 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  crc-version:
+    description: 'The CRC version used'
+    value: ${{ steps.crc_version_lookup.outputs.version_number }}
+  ocp-version:
+    description: 'The deployed OpenShift version'
+    value: ${{ steps.ocp_version_lookup.outputs.ocp_version }}
+  api-url:
+    description: 'The OpenShift API server URL'
+    value: ${{ steps.cluster_credentials.outputs.api-url }}
+  console-url:
+    description: 'The OpenShift web console URL'
+    value: ${{ steps.cluster_credentials.outputs.console-url }}
+  kubeadmin-password:
+    description: 'The kubeadmin password for cluster authentication'
+    value: ${{ steps.cluster_credentials.outputs.kubeadmin-password }}
+
 runs:
   using: 'composite'
   steps:
@@ -164,6 +181,11 @@ runs:
     - name: Wait until node is Ready state
       shell: bash
       run: ${{ github.action_path }}/scripts/wait-for-node-ready.sh
+
+    - name: Get cluster credentials
+      id: cluster_credentials
+      shell: bash
+      run: ${{ github.action_path }}/scripts/get-cluster-credentials.sh
 
     - name: Disable non-essential OpenShift operators to save resources
       shell: bash

--- a/scripts/get-cluster-credentials.sh
+++ b/scripts/get-cluster-credentials.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+echo "=== Retrieving cluster credentials ==="
+
+KUBEADMIN_PASSWORD=$(crc console --credentials | grep 'password is' | awk '{print $NF}' | tr -d "'" | head -1)
+echo "::add-mask::$KUBEADMIN_PASSWORD"
+
+API_URL="https://api.crc.testing:6443"
+CONSOLE_URL="https://console-openshift-console.apps-crc.testing"
+
+echo "api-url=$API_URL" | tee -a "${GITHUB_OUTPUT}"
+echo "console-url=$CONSOLE_URL" | tee -a "${GITHUB_OUTPUT}"
+echo "kubeadmin-password=$KUBEADMIN_PASSWORD" | tee -a "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

- Add 5 action outputs: `crc-version`, `ocp-version`, `api-url`, `console-url`, `kubeadmin-password`
- New `scripts/get-cluster-credentials.sh` extracts the kubeadmin password from CRC and sets output values
- Kubeadmin password is masked in workflow logs via `::add-mask::`

Users can now access cluster details in downstream steps:

```yaml
- uses: palmsoftware/quick-ocp@v0
  id: ocp
  with:
    ocpPullSecret: $OCP_PULL_SECRET

- name: Use cluster
  run: |
    echo "OCP version: ${{ steps.ocp.outputs.ocp-version }}"
    echo "API URL: ${{ steps.ocp.outputs.api-url }}"
    oc login ${{ steps.ocp.outputs.api-url }} -u kubeadmin -p ${{ steps.ocp.outputs.kubeadmin-password }}
```

## Test plan

- [ ] CI passes — new script runs after node ready, before operator scaling
- [ ] Verify outputs are set by checking step logs for `api-url=`, `console-url=`, `kubeadmin-password=` lines