### PR TITLE
fix: detect non-kubeconfig CRC start failures

### DIFF
--- a/scripts/run-crc-setup.sh
+++ b/scripts/run-crc-setup.sh
@@ -14,24 +14,27 @@ attempt=1
 while [ $attempt -le $max_attempts ]; do
   echo "=== CRC start attempt $attempt of $max_attempts ==="
 
-  start_output=$(sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug 2>&1) || true
+  start_exit_code=0
+  start_output=$(sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug 2>&1) || start_exit_code=$?
   echo "$start_output"
 
+  if [ $start_exit_code -eq 0 ]; then
+    break
+  fi
+
   if echo "$start_output" | grep -qi "failed to update kubeconfig\|cannot update kubeconfig"; then
-    echo "WARNING: kubeconfig update failed during CRC start"
+    echo "WARNING: kubeconfig update failed during CRC start (exit code $start_exit_code)"
     if [ $attempt -lt $max_attempts ]; then
       echo "Stopping CRC and retrying..."
       sudo -su $USER crc stop || true
       sleep 10
       attempt=$((attempt + 1))
       continue
-    else
-      echo "ERROR: All $max_attempts attempts failed with kubeconfig error"
-      exit 1
     fi
   fi
 
-  break
+  echo "ERROR: CRC start failed (exit code $start_exit_code) on attempt $attempt of $max_attempts"
+  exit 1
 done
 
 # Clean up pull secret immediately after use


### PR DESCRIPTION
## Summary

- Capture the `crc start` exit code instead of swallowing all errors with `|| true`
- On exit 0, break immediately (explicit success check)
- On kubeconfig errors, retry as before (up to 3 attempts)
- On any other non-zero exit, fail immediately with the exit code instead of silently continuing with a broken cluster

## Test plan

- [ ] CI passes — all OCP deploy jobs succeed on exit 0
- [ ] Kubeconfig retry logic still works (tested by existing CI matrix including pinned 4.19)