### PR TITLE
fix: remove ubuntu-26.04 from CI matrices until CRC upstream fix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         ocp: ['4.18', '4.19', '4.20', '4.21', 'latest']
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         ocp: ['4.18', '4.19', '4.20', '4.21', 'latest']
     runs-on: ${{ matrix.os }}
     env:

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ If you are looking to quickly spawn Kubernetes in your Action runner, try [quick
 
 This action is tested on the following GitHub Actions runners:
 
-- `ubuntu-26.04`
 - `ubuntu-24.04`
 - `ubuntu-22.04`
 
 # Known Limitations:
 
-- This does not run correctly on `ubuntu-20.04` runners due to the version of `libvirt` available in the mirrors isn't the minimum version required by OpenShift Local.
+- `ubuntu-26.04` is not yet supported due to CRC VM SSH connectivity failures with the ubuntu-26.04 libvirt/kernel stack. The dependency setup is in place and will be re-enabled once CRC upstream resolves this.
+- `ubuntu-20.04` is not supported due to the version of `libvirt` available in the mirrors not meeting the minimum version required by OpenShift Local.
 
 # Connectivity Requirements:
 


### PR DESCRIPTION
## Summary
- Remove ubuntu-26.04 from nightly and pre-main CI matrices — CRC VMs consistently fail to establish SSH on ubuntu-26.04 runners (100% failure rate across all OCP versions and 3 retry attempts)
- Update README to document ubuntu-26.04 as a known limitation
- Keep the virtiofsd dependency setup and SSH retry logic from #62 as good hardening

## Context
PR #62 added ubuntu-26.04 support but all 26.04 jobs fail with `Failed to connect to the CRC VM with SSH -- virtual machine might be unreachable`. This is a CRC/libvirt incompatibility with the ubuntu-26.04 kernel stack, not a quick-ocp issue. Will re-enable once CRC upstream resolves this.

## Test plan
- [ ] CI passes (ubuntu-24.04 and ubuntu-22.04 matrices only)