### PR TITLE
feat: add ubuntu-26.04 dependency prep and CRC reliability improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@ Read more about Github Actions runners [here](https://docs.github.com/en/actions
 
 If you are looking to quickly spawn Kubernetes in your Action runner, try [quick-k8s](https://github.com/palmsoftware/quick-k8s).
 
+# Supported Runners
+
+This action is tested on the following GitHub Actions runners:
+
+- `ubuntu-24.04`
+- `ubuntu-22.04`
+
 # Known Limitations:
 
-- This does not run correctly on `ubuntu-20.04` runners due to the version of `libvirt` available in the mirrors isn't the minimum version required by OpenShift Local.
+- `ubuntu-26.04` is not yet supported due to a CRC vsock SSH incompatibility with Linux kernel 7.0. See [crc-org/crc#5283](https://github.com/crc-org/crc/issues/5283) for tracking.
+- `ubuntu-20.04` is not supported due to the version of `libvirt` available in the mirrors not meeting the minimum version required by OpenShift Local.
 
 # Connectivity Requirements:
 

--- a/scripts/enable-kvm-perms.sh
+++ b/scripts/enable-kvm-perms.sh
@@ -2,8 +2,12 @@
 set -e
 
 echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+echo 'KERNEL=="vhost-vsock", GROUP="kvm", MODE="0666"' | sudo tee -a /etc/udev/rules.d/99-kvm4all.rules
 sudo udevadm control --reload-rules
 sudo udevadm trigger --name-match=kvm
+sudo udevadm trigger --name-match=vhost-vsock 2>/dev/null || true
+sudo chmod 0666 /dev/kvm 2>/dev/null || true
+sudo chmod 0666 /dev/vhost-vsock 2>/dev/null || true
 sudo apt-get install -y libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils qemu-system-x86
 sudo usermod -a -G kvm,libvirt $USER
 if ! groups $USER | grep -q libvirt; then
@@ -11,3 +15,6 @@ if ! groups $USER | grep -q libvirt; then
 else
   echo "User already in libvirt group"
 fi
+echo "=== KVM permissions check ==="
+ls -la /dev/kvm /dev/vhost-vsock 2>/dev/null || true
+id

--- a/scripts/install-ubuntu-dependencies.sh
+++ b/scripts/install-ubuntu-dependencies.sh
@@ -17,6 +17,15 @@ elif [[ "$UBUNTU_VERSION" == "24.04" ]]; then
   else
     echo "virtqemud.socket unit file does not exist. Skipping enable/start steps."
   fi
+elif [[ "$UBUNTU_VERSION" == "26.04" ]]; then
+  echo "Installing specific dependencies for Ubuntu 26.04"
+  sudo apt-get update
+  sudo apt-get install -y virtiofsd libvirt-daemon-system libvirt-daemon-driver-qemu qemu-system-x86
+  if systemctl list-unit-files | grep -q libvirtd.socket; then
+    sudo systemctl enable libvirtd.socket
+    sudo systemctl start libvirtd.socket
+  fi
+  sudo modprobe vhost_vsock || true
 else
   echo "No specific dependencies for Ubuntu version $UBUNTU_VERSION"
 fi

--- a/scripts/run-crc-setup.sh
+++ b/scripts/run-crc-setup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+echo "=== CRC preflight check ==="
+sudo -su $USER crc setup --check-only 2>&1 || true
+
 echo "=== Running CRC setup ==="
 sudo -su $USER crc setup --log-level debug --show-progressbars
 
@@ -15,15 +18,16 @@ while [ $attempt -le $max_attempts ]; do
   echo "=== CRC start attempt $attempt of $max_attempts ==="
 
   start_exit_code=0
-  start_output=$(sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug 2>&1) || start_exit_code=$?
-  echo "$start_output"
+  start_log="/tmp/crc-start-attempt-${attempt}.log"
+  sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug 2>&1 | tee "$start_log" || start_exit_code=$?
+  start_output=$(cat "$start_log")
 
   if [ $start_exit_code -eq 0 ]; then
     break
   fi
 
-  if echo "$start_output" | grep -qi "failed to update kubeconfig\|cannot update kubeconfig"; then
-    echo "WARNING: kubeconfig update failed during CRC start (exit code $start_exit_code)"
+  if echo "$start_output" | grep -qi "failed to update kubeconfig\|cannot update kubeconfig\|Failed to connect to the CRC VM with SSH"; then
+    echo "WARNING: CRC start failed with retryable error (exit code $start_exit_code)"
     if [ $attempt -lt $max_attempts ]; then
       echo "Stopping CRC and retrying..."
       sudo -su $USER crc stop || true

--- a/scripts/wait-for-node-ready.sh
+++ b/scripts/wait-for-node-ready.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 set -e
 
-timeout=600 # 10 minutes in seconds
+timeout=900 # 15 minutes in seconds
 elapsed=0
 interval=10
+
+# Debug: show CRC status and connectivity
+echo "=== CRC status ==="
+crc status 2>&1 || true
+echo "=== DNS check ==="
+getent hosts api.crc.testing 2>&1 || echo "api.crc.testing: not resolving"
+echo "=== Connectivity check ==="
+curl -sk --connect-timeout 5 https://api.crc.testing:6443 2>&1 | head -3 || true
 
 # Wait for cluster to be ready and accessible
 echo "Waiting for cluster to be accessible..."


### PR DESCRIPTION
## Summary
- Add ubuntu-26.04 dependency setup (virtiofsd, libvirtd, qemu-system-x86, vhost-vsock permissions) in preparation for when CRC supports kernel 7.0
- Extend CRC start retry logic to handle SSH connection failures in addition to kubeconfig failures
- Add `crc setup --check-only` preflight diagnostic before setup
- Increase cluster accessibility timeout from 600s to 900s with CRC status/DNS/connectivity diagnostics
- Add udev rule and permissions fix for `/dev/vhost-vsock` device
- Document ubuntu-26.04 as a known limitation pending CRC upstream fix

## Context
Ubuntu 26.04 (kernel 7.0) has a vsock SSH incompatibility with CRC's gvforwarder that prevents OpenShift Local from establishing SSH to the VM. This is tracked upstream at [crc-org/crc#5283](https://github.com/crc-org/crc/issues/5283). The dependency and permissions changes in this PR prepare the codebase so ubuntu-26.04 can be enabled once CRC resolves the kernel 7.0 vsock issue.

## Related PRs
- [quick-k8s PR #165](https://github.com/palmsoftware/quick-k8s/pull/165) — ubuntu-26.04 support (merged, all jobs pass)
- [quick-cleanup PR #8](https://github.com/palmsoftware/quick-cleanup/pull/8) — ubuntu-26.04 support (merged, all jobs pass)

## Test plan
- [x] All 15 CI checks pass (10 OCP matrix jobs, 2 feature tests, lint, CodeQL, Analyze)
- [x] ubuntu-22.04 and ubuntu-24.04 matrix jobs unaffected by changes
