### PR TITLE
fix: align version validation regex to 4.18+

### DIFF
--- a/scripts/fetch-ocp-crc-version.sh
+++ b/scripts/fetch-ocp-crc-version.sh
@@ -10,9 +10,9 @@ if [ -z "$1" ]; then
 fi
 OCP_VERSION="$1"
 
-# Only support OCP versions 4.10 and above
-if ! [[ "$OCP_VERSION" =~ ^4\.([1-9][0-9]|10)$ ]]; then
-  echo "Error: Only OCP versions 4.10 and above are supported (e.g., 4.18, 4.20)." >&2
+# Only support OCP versions 4.18 and above
+if ! [[ "$OCP_VERSION" =~ ^4\.(1[8-9]|[2-9][0-9])$ ]]; then
+  echo "Error: Only OCP versions 4.18 and above are supported (e.g., 4.18, 4.19, 4.20)." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

- Update `fetch-ocp-crc-version.sh` regex from `^4\.([1-9][0-9]|10)$` (accepts 4.10+) to `^4\.(1[8-9]|[2-9][0-9])$` (accepts 4.18+)
- Aligns with the stricter validation already enforced by `set-crc-version.sh` and the versions in `crc-version-pins.json`
- Update comment and error message to reflect the 4.18+ minimum

Closes #80