### PR TITLE
feat: add kubeconfig-path output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,9 @@ outputs:
   kubeadmin-password:
     description: 'The kubeadmin password for cluster authentication'
     value: ${{ steps.cluster_credentials.outputs.kubeadmin-password }}
+  kubeconfig-path:
+    description: 'The path to the kubeconfig file for cluster access'
+    value: ${{ steps.cluster_credentials.outputs.kubeconfig-path }}
   setup-duration:
     description: 'Total deployment time in seconds'
     value: ${{ steps.deployment_duration.outputs.duration }}

--- a/scripts/get-cluster-credentials.sh
+++ b/scripts/get-cluster-credentials.sh
@@ -9,6 +9,9 @@ echo "::add-mask::$KUBEADMIN_PASSWORD"
 API_URL="https://api.crc.testing:6443"
 CONSOLE_URL="https://console-openshift-console.apps-crc.testing"
 
+KUBECONFIG_PATH="$HOME/.crc/machines/crc/kubeconfig"
+
 echo "api-url=$API_URL" >>"${GITHUB_OUTPUT}"
 echo "console-url=$CONSOLE_URL" >>"${GITHUB_OUTPUT}"
 echo "kubeadmin-password=$KUBEADMIN_PASSWORD" >>"${GITHUB_OUTPUT}"
+echo "kubeconfig-path=$KUBECONFIG_PATH" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

- Adds `kubeconfig-path` output exposing the CRC kubeconfig file path (`~/.crc/machines/crc/kubeconfig`)
- Allows users to set `KUBECONFIG` for helm, kustomize, and other Kubernetes-native tools

Closes #76