### PR TITLE
feat: add configurable operator wait timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: 'Enable the cluster monitoring stack (requires minimum 14GiB memory)'
     required: false
     default: 'false'
+  operatorTimeout:
+    description: 'Timeout in seconds for waiting for operators to become ready'
+    required: false
+    default: '600'
   preloadImages:
     description: 'Newline-separated list of container images to preload into the cluster registry'
     required: false
@@ -205,7 +209,7 @@ runs:
     - name: Wait for operators to be available
       if: ${{ inputs.waitForOperatorsReady == 'true' }}
       shell: bash
-      run: ${{ github.action_path }}/scripts/wait-for-operators.sh
+      run: ${{ github.action_path }}/scripts/wait-for-operators.sh "${{ inputs.operatorTimeout }}"
 
     - name: Comprehensive Disk Space Report
       shell: bash

--- a/scripts/wait-for-operators.sh
+++ b/scripts/wait-for-operators.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e
 
-timeout=600 # 10 minutes in seconds
+timeout="${1:-600}"
+[[ "$timeout" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: invalid timeout value: $timeout" >&2
+  exit 1
+}
 elapsed=0
 interval=10
 


### PR DESCRIPTION
## Summary

- Adds `operatorTimeout` input (default: 600 seconds) for controlling how long to wait for operators
- Useful when `enableClusterMonitoring: true` causes operators to need longer to stabilize
- Includes input validation to reject non-numeric values

Closes #77