### PR TITLE
feat: add shellcheck to Makefile and CI, fix all findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ help: ## Show this help message
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-lint: ## Check shell script formatting
-	@echo "Linting shell scripts in scripts/ directory..."
+lint: ## Check shell script formatting and correctness
+	@echo "Checking shell script formatting..."
 	@shfmt -d -i 2 -ci scripts/*.sh
+	@echo "Running shellcheck..."
+	@shellcheck scripts/*.sh
 
 fix-lint: ## Fix shell script formatting issues
 	@echo "Fixing shell script formatting in scripts/ directory..."

--- a/scripts/comprehensive-disk-report.sh
+++ b/scripts/comprehensive-disk-report.sh
@@ -77,6 +77,7 @@ fi
 
 echo ""
 echo "=== Largest Files (top 10) ==="
+# shellcheck disable=SC2016
 find / -type f -size +100M 2>/dev/null | head -10 | xargs -I {} sh -c 'echo "$(du -h "{}" 2>/dev/null | cut -f1) {}"' 2>/dev/null || echo "Could not analyze large files"
 
 echo ""

--- a/scripts/configure-crc.sh
+++ b/scripts/configure-crc.sh
@@ -35,9 +35,9 @@ if [ "$ENABLE_CLUSTER_MONITORING" = "true" ]; then
 fi
 
 echo "=== Configuring CRC for minimal resource usage ==="
-crc config set cpus $CRC_CPU
-crc config set memory $CRC_MEMORY
-crc config set disk-size $CRC_DISK_SIZE
+crc config set cpus "$CRC_CPU"
+crc config set memory "$CRC_MEMORY"
+crc config set disk-size "$CRC_DISK_SIZE"
 if [ "$ENABLE_TELEMETRY" = "true" ]; then
   crc config set consent-telemetry yes
 elif [ "$ENABLE_TELEMETRY" = "false" ]; then

--- a/scripts/download-install-crc.sh
+++ b/scripts/download-install-crc.sh
@@ -52,8 +52,9 @@ if [ "$DOWNLOAD_SUCCESS" = false ]; then
 fi
 
 tar -xf crc.tar.xz
-if [ -d crc-linux-* ] && [ -f crc-linux-*/crc ]; then
-  sudo mv crc-linux-*/crc /usr/local/bin
+CRC_DIR=$(find . -maxdepth 1 -type d -name 'crc-linux-*' | head -1)
+if [ -n "$CRC_DIR" ] && [ -f "$CRC_DIR/crc" ]; then
+  sudo mv "$CRC_DIR/crc" /usr/local/bin
 else
   echo "Error: CRC binary not found in extracted archive"
   exit 1

--- a/scripts/enable-kvm-perms.sh
+++ b/scripts/enable-kvm-perms.sh
@@ -9,9 +9,9 @@ sudo udevadm trigger --name-match=vhost-vsock 2>/dev/null || true
 sudo chmod 0666 /dev/kvm 2>/dev/null || true
 sudo chmod 0666 /dev/vhost-vsock 2>/dev/null || true
 sudo apt-get install -y libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils qemu-system-x86
-sudo usermod -a -G kvm,libvirt $USER
-if ! groups $USER | grep -q libvirt; then
-  sudo adduser $(id -un) libvirt
+sudo usermod -a -G kvm,libvirt "$USER"
+if ! groups "$USER" | grep -q libvirt; then
+  sudo adduser "$(id -un)" libvirt
 else
   echo "User already in libvirt group"
 fi

--- a/scripts/get-cluster-credentials.sh
+++ b/scripts/get-cluster-credentials.sh
@@ -11,7 +11,9 @@ CONSOLE_URL="https://console-openshift-console.apps-crc.testing"
 
 KUBECONFIG_PATH="$HOME/.crc/machines/crc/kubeconfig"
 
-echo "api-url=$API_URL" >>"${GITHUB_OUTPUT}"
-echo "console-url=$CONSOLE_URL" >>"${GITHUB_OUTPUT}"
-echo "kubeadmin-password=$KUBEADMIN_PASSWORD" >>"${GITHUB_OUTPUT}"
-echo "kubeconfig-path=$KUBECONFIG_PATH" >>"${GITHUB_OUTPUT}"
+{
+  echo "api-url=$API_URL"
+  echo "console-url=$CONSOLE_URL"
+  echo "kubeadmin-password=$KUBEADMIN_PASSWORD"
+  echo "kubeconfig-path=$KUBECONFIG_PATH"
+} >>"${GITHUB_OUTPUT}"

--- a/scripts/install-oc-tools.sh
+++ b/scripts/install-oc-tools.sh
@@ -18,7 +18,7 @@ fi
 MIRROR_DOMAIN='https://mirror.openshift.com'
 USEROVERRIDE=false
 
-if [ -z ${ARCH} ]; then
+if [ -z "${ARCH}" ]; then
   ARCH=$(uname -m)
   if [ "${ARCH}" == 'x86_64' ]; then
     MIRROR_PATH='/pub/openshift-v4/x86_64/clients'
@@ -55,6 +55,7 @@ setup() {
   # Allow user overrides
   if [ -f "${OCTOOLSRC}" ]; then
     echo ".octoolsrc file detected, overriding defaults..."
+    # shellcheck source=/dev/null
     source "${OCTOOLSRC}"
     USEROVERRIDE=true
     if [ ! -d "${BIN_PATH}" ]; then
@@ -125,7 +126,7 @@ check_root() {
 check_prereq() {
 
   #Check for wget
-  if [ ! $(command -v wget) ]; then
+  if [ ! "$(command -v wget)" ]; then
     echo "wget not found. Please install wget."
     exit 1
   fi
@@ -269,7 +270,7 @@ release() {
   if [[ $1 =~ ^4+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Specific version specified. Downloading that version."
     printf "\n"
-    version $1
+    version "$1"
     exit 0
   fi
 
@@ -351,16 +352,16 @@ nightly() {
 
 download() {
 
-  echo -n "Downloading $(echo $1 | awk -F/ '{ print $NF }'):    "
-  wget --progress=dot "$1" -O "/tmp/$(echo $1 | awk -F/ '{ print $NF }')" 2>&1 |
+  echo -n "Downloading $(echo "$1" | awk -F/ '{ print $NF }'):    "
+  wget --progress=dot "$1" -O "/tmp/$(echo "$1" | awk -F/ '{ print $NF }')" 2>&1 |
     grep --line-buffered "%" |
     sed -e "s,\.,,g" |
     awk '{printf("\b\b\b\b%4s", $2)}'
   echo -ne "\b\b\b\b"
   echo " Download Complete."
 
-  echo -n "Downloading $(echo $2 | awk -F/ '{ print $NF }'):    "
-  wget --progress=dot "$2" -O "/tmp/$(echo $2 | awk -F/ '{ print $NF }')" 2>&1 |
+  echo -n "Downloading $(echo "$2" | awk -F/ '{ print $NF }'):    "
+  wget --progress=dot "$2" -O "/tmp/$(echo "$2" | awk -F/ '{ print $NF }')" 2>&1 |
     grep --line-buffered "%" |
     sed -e "s,\.,,g" |
     awk '{printf("\b\b\b\b%4s", $2)}'
@@ -375,7 +376,7 @@ backup() {
 
   CUR_VERSION=$(oc version 2>/dev/null | grep Client | sed -e 's/Client Version: //')
   if [[ -f "${BIN_PATH}/oc" ]] && [[ -f "${BIN_PATH}/openshift-install" ]] && [[ -f "${BIN_PATH}/kubectl" ]]; then
-    for i in openshift-install oc kubectl; do mv "$(which $i)" ${BIN_PATH}/"$i"."$CUR_VERSION".bak; done
+    for i in openshift-install oc kubectl; do mv "$(which "$i")" "${BIN_PATH}"/"$i"."$CUR_VERSION".bak; done
   fi
 
   if [[ "$1" == "extract" ]]; then
@@ -386,10 +387,10 @@ backup() {
 
 extract() {
 
-  echo -e "\nExtracting oc and kubectl from $(echo $CLIENT | awk -F/ '{ print $NF }') to ${BIN_PATH}"
-  tar -zxf "/tmp/$(echo $CLIENT | awk -F/ '{ print $NF }')" -C ${BIN_PATH}
-  echo -e "\nExtracting openshift-install from $(echo $INSTALL | awk -F/ '{ print $NF }') to ${BIN_PATH}"
-  tar -zxf "/tmp/$(echo $INSTALL | awk -F/ '{ print $NF}')" -C ${BIN_PATH}
+  echo -e "\nExtracting oc and kubectl from $(echo "$CLIENT" | awk -F/ '{ print $NF }') to ${BIN_PATH}"
+  tar -zxf "/tmp/$(echo "$CLIENT" | awk -F/ '{ print $NF }')" -C "${BIN_PATH}"
+  echo -e "\nExtracting openshift-install from $(echo "$INSTALL" | awk -F/ '{ print $NF }') to ${BIN_PATH}"
+  tar -zxf "/tmp/$(echo "$INSTALL" | awk -F/ '{ print $NF }')" -C "${BIN_PATH}"
 
   if [[ "$1" == "cleanup" ]]; then
     cleanup
@@ -399,7 +400,7 @@ extract() {
 
 cleanup() {
 
-  rm -rf ${BIN_PATH}/README.md
+  rm -rf "${BIN_PATH}"/README.md
   rm -rf "/tmp/openshift-client-${OS}.tar.gz"
   rm -rf "/tmp/openshift-install-${OS}.tar.gz"
 
@@ -409,14 +410,14 @@ cleanup() {
 
 remove_old_ver() {
 
-  if ls ${BIN_PATH}/oc*bak 1>/dev/null 2>&1 && ls ${BIN_PATH}/openshift-install*bak 1>/dev/null 2>&1 && ls ${BIN_PATH}/kubectl*bak 1>/dev/null 2>&1; then
+  if ls "${BIN_PATH}"/oc*bak 1>/dev/null 2>&1 && ls "${BIN_PATH}"/openshift-install*bak 1>/dev/null 2>&1 && ls "${BIN_PATH}"/kubectl*bak 1>/dev/null 2>&1; then
     read -rp "Delete the following files?
 $(echo -e "\n")
-$(for i in oc kubectl openshift-install; do ls -1 ${BIN_PATH}/$i*bak 2>/dev/null; done)
+$(for i in oc kubectl openshift-install; do ls -1 "${BIN_PATH}"/$i*bak 2>/dev/null; done)
 $(echo -e "\nY/N? ")"
 
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-      for i in oc kubectl openshift-install; do rm -f ${BIN_PATH}/$i*bak 2>/dev/null; done
+      for i in oc kubectl openshift-install; do rm -f "${BIN_PATH}"/$i*bak 2>/dev/null; done
       exit 0
     elif [[ $REPLY =~ ^[Nn]$ ]]; then
       exit 0
@@ -435,16 +436,16 @@ uninstall() {
 
   check_root
 
-  if ls ${BIN_PATH}/oc 1>/dev/null 2>&1 && ls ${BIN_PATH}/openshift-install 1>/dev/null 2>&1 && ls ${BIN_PATH}/kubectl 1>/dev/null 2>&1; then
+  if ls "${BIN_PATH}"/oc 1>/dev/null 2>&1 && ls "${BIN_PATH}"/openshift-install 1>/dev/null 2>&1 && ls "${BIN_PATH}"/kubectl 1>/dev/null 2>&1; then
     read -rp "Delete the following files?
 $(echo -e "\n")
-$(for i in oc kubectl openshift-install; do ls -1 ${BIN_PATH}/$i 2>/dev/null; done)
-$(for i in oc kubectl openshift-install; do ls -1 ${BIN_PATH}/$i*bak 2>/dev/null; done)
+$(for i in oc kubectl openshift-install; do ls -1 "${BIN_PATH}"/$i 2>/dev/null; done)
+$(for i in oc kubectl openshift-install; do ls -1 "${BIN_PATH}"/$i*bak 2>/dev/null; done)
 $(echo -e "\nY/N? ")"
 
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-      for i in oc kubectl openshift-install; do rm -f ${BIN_PATH}/$i*bak 2>/dev/null; done
-      for i in oc kubectl openshift-install; do rm -f ${BIN_PATH}/$i 2>/dev/null; done
+      for i in oc kubectl openshift-install; do rm -f "${BIN_PATH}"/$i*bak 2>/dev/null; done
+      for i in oc kubectl openshift-install; do rm -f "${BIN_PATH}"/$i 2>/dev/null; done
       exit 0
     elif [[ $REPLY =~ ^[Nn]$ ]]; then
       exit 0
@@ -468,7 +469,7 @@ show_ver() {
     echo "Error getting oc version. Please rerun script."
   fi
 
-  if [ ${oc_version} -lt 15 ]; then
+  if [ "${oc_version}" -lt 15 ]; then
     if which kubectl &>/dev/null; then
       echo -e "\nkubectl version: $(kubectl version --client | grep -o "GitVersion:.*" | cut -d, -f1)"
     else
@@ -585,7 +586,7 @@ cli_path() {
     fi
   fi
 
-  download_cli $MIRROR_CLI_PATH "$1"
+  download_cli "$MIRROR_CLI_PATH" "$1"
 
 }
 
@@ -593,9 +594,9 @@ download_cli() {
 
   check_root
 
-  filename=$(echo $1 | awk -F/ '{ print $NF }')
+  filename=$(echo "$1" | awk -F/ '{ print $NF }')
   echo -n "Downloading $filename:    "
-  wget --progress=dot "$1" -O "/tmp/$(echo $1 | awk -F/ '{ print $NF }')" 2>&1 |
+  wget --progress=dot "$1" -O "/tmp/$(echo "$1" | awk -F/ '{ print $NF }')" 2>&1 |
     grep --line-buffered "%" |
     sed -e "s,\.,,g" |
     awk '{printf("\b\b\b\b%4s", $2)}'
@@ -603,10 +604,10 @@ download_cli() {
   echo " Download Complete."
 
   if [[ "$2" == "serverless" ]]; then
-    tar -zxf "/tmp/$(echo $1 | awk -F/ '{ print $NF }')" -C ${BIN_PATH}
-    rm "/tmp/$(echo $1 | awk -F/ '{ print $NF }')"
+    tar -zxf "/tmp/$(echo "$1" | awk -F/ '{ print $NF }')" -C "${BIN_PATH}"
+    rm "/tmp/$(echo "$1" | awk -F/ '{ print $NF }')"
   else
-    cp "/tmp/$(echo $1 | awk -F/ '{ print $NF }')" ${BIN_PATH}
+    cp "/tmp/$(echo "$1" | awk -F/ '{ print $NF }')" "${BIN_PATH}"
     chmod +x "${BIN_PATH}/$filename"
   fi
 

--- a/scripts/move-crc-bundles-to-temp.sh
+++ b/scripts/move-crc-bundles-to-temp.sh
@@ -5,7 +5,7 @@ echo "=== Moving CRC bundles for caching ==="
 mkdir -p "$HOME/.crc/bundletmp"
 if [ -n "$(ls "$HOME/.crc/cache"/*.crcbundle 2>/dev/null)" ]; then
   mv "$HOME/.crc/cache"/*.crcbundle "$HOME/.crc/bundletmp/"
-  echo "Moved $(ls "$HOME/.crc/bundletmp"/*.crcbundle | wc -l) bundle files"
+  echo "Moved $(find "$HOME/.crc/bundletmp" -name '*.crcbundle' | wc -l) bundle files"
 else
   echo "No .crcbundle files found to move"
 fi

--- a/scripts/run-crc-setup.sh
+++ b/scripts/run-crc-setup.sh
@@ -4,10 +4,10 @@ set -eo pipefail
 trap 'rm -f pull-secret.json' EXIT
 
 echo "=== CRC preflight check ==="
-sudo -su $USER crc setup --check-only 2>&1 || true
+sudo -su "$USER" crc setup --check-only 2>&1 || true
 
 echo "=== Running CRC setup ==="
-sudo -su $USER crc setup --log-level debug --show-progressbars
+sudo -su "$USER" crc setup --log-level debug --show-progressbars
 
 echo "=== Disk usage after CRC setup ==="
 df -h
@@ -21,7 +21,7 @@ while [ $attempt -le $max_attempts ]; do
 
   start_exit_code=0
   start_log="/tmp/crc-start-attempt-${attempt}.log"
-  sudo -su $USER crc start --pull-secret-file pull-secret.json --log-level debug 2>&1 | tee "$start_log" || start_exit_code=$?
+  sudo -su "$USER" crc start --pull-secret-file pull-secret.json --log-level debug 2>&1 | tee "$start_log" || start_exit_code=$?
   start_output=$(cat "$start_log")
 
   if [ $start_exit_code -eq 0 ]; then
@@ -32,7 +32,7 @@ while [ $attempt -le $max_attempts ]; do
     echo "WARNING: CRC start failed with retryable error (exit code $start_exit_code)"
     if [ $attempt -lt $max_attempts ]; then
       echo "Stopping CRC and retrying..."
-      sudo -su $USER crc stop || true
+      sudo -su "$USER" crc stop || true
       sleep 10
       attempt=$((attempt + 1))
       continue

--- a/scripts/wait-for-operators.sh
+++ b/scripts/wait-for-operators.sh
@@ -15,9 +15,9 @@ while true; do
     break
   else
     echo "Waiting for operators to become available..."
-    sleep $interval
+    sleep "$interval"
     elapsed=$((elapsed + interval))
-    if [ $elapsed -ge $timeout ]; then
+    if [ "$elapsed" -ge "$timeout" ]; then
       echo "Timeout reached: Not all operators are available"
       exit 1
     fi


### PR DESCRIPTION
## Summary

- Adds shellcheck to the make lint target alongside shfmt
- Fixes all existing shellcheck findings across 8 scripts:
  - Quote variables to prevent word splitting (SC2086)
  - Fix glob-in-test bug in download-install-crc.sh (SC2144)
  - Group redirects in get-cluster-credentials.sh (SC2129)
  - Use find instead of ls in move-crc-bundles-to-temp.sh (SC2012)
  - Add directives for intentional patterns (SC2016, SC1090)

Closes #78