### PR TITLE
feat: add proxy configuration support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,22 @@ inputs:
     description: 'Timeout in seconds for waiting for operators to become ready'
     required: false
     default: '600'
+  httpProxy:
+    description: 'HTTP proxy URL for CRC (e.g., http://proxy.example.com:8080)'
+    required: false
+    default: ''
+  httpsProxy:
+    description: 'HTTPS proxy URL for CRC (e.g., http://proxy.example.com:8080)'
+    required: false
+    default: ''
+  noProxy:
+    description: 'Comma-separated list of hosts/domains to exclude from proxying'
+    required: false
+    default: ''
+  proxyCaFile:
+    description: 'Path to a CA certificate file for the proxy'
+    required: false
+    default: ''
   preloadImages:
     description: 'Newline-separated list of container images to preload into the cluster registry'
     required: false
@@ -180,6 +196,11 @@ runs:
 
     - name: Start OpenShift Local
       shell: bash
+      env:
+        HTTP_PROXY_INPUT: ${{ inputs.httpProxy }}
+        HTTPS_PROXY_INPUT: ${{ inputs.httpsProxy }}
+        NO_PROXY_INPUT: ${{ inputs.noProxy }}
+        PROXY_CA_FILE_INPUT: ${{ inputs.proxyCaFile }}
       run: ${{ github.action_path }}/scripts/configure-crc.sh "${{ inputs.crcCpu }}" "${{ inputs.crcMemory }}" "${{ inputs.crcDiskSize }}" "${{ inputs.enableTelemetry }}" "${{ inputs.enableClusterMonitoring }}"
 
     - name: Run setup

--- a/scripts/configure-crc.sh
+++ b/scripts/configure-crc.sh
@@ -52,3 +52,20 @@ if [ "$ENABLE_CLUSTER_MONITORING" = "true" ]; then
   echo "=== Enabling cluster monitoring stack ==="
   crc config set enable-cluster-monitoring true
 fi
+
+if [ -n "${HTTP_PROXY_INPUT:-}" ]; then
+  echo "=== Configuring HTTP proxy ==="
+  crc config set http-proxy "$HTTP_PROXY_INPUT"
+fi
+if [ -n "${HTTPS_PROXY_INPUT:-}" ]; then
+  echo "=== Configuring HTTPS proxy ==="
+  crc config set https-proxy "$HTTPS_PROXY_INPUT"
+fi
+if [ -n "${NO_PROXY_INPUT:-}" ]; then
+  echo "=== Configuring no-proxy list ==="
+  crc config set no-proxy "$NO_PROXY_INPUT"
+fi
+if [ -n "${PROXY_CA_FILE_INPUT:-}" ]; then
+  echo "=== Configuring proxy CA file ==="
+  crc config set proxy-ca-file "$PROXY_CA_FILE_INPUT"
+fi


### PR DESCRIPTION
## Summary

- Adds httpProxy, httpsProxy, noProxy, and proxyCaFile inputs for users behind corporate proxies
- Values are passed via env vars (with _INPUT suffix to avoid collisions with standard proxy env vars)
- Only configures CRC proxy settings when a value is provided — no-op when inputs are empty

Closes #86