### PR TITLE
fix: add diagnostic output on operator wait timeout

### DIFF
--- a/scripts/wait-for-operators.sh
+++ b/scripts/wait-for-operators.sh
@@ -18,7 +18,10 @@ while true; do
     sleep "$interval"
     elapsed=$((elapsed + interval))
     if [ "$elapsed" -ge "$timeout" ]; then
-      echo "Timeout reached: Not all operators are available"
+      echo "Timeout reached: Not all operators are available after ${timeout}s"
+      echo ""
+      echo "=== Cluster Operator Status ==="
+      oc get co 2>&1 || true
       exit 1
     fi
   fi


### PR DESCRIPTION
## Summary

- Dumps full `oc get co` output when operator wait times out
- Shows which operators are degraded, progressing, or unavailable instead of just a generic timeout message

Closes #72