### PR TITLE
fix: improve nightly test reliability with better retry logic and diagnostics

### DIFF
--- a/scripts/check-connectivity.sh
+++ b/scripts/check-connectivity.sh
@@ -19,22 +19,30 @@ check_service() {
   # -s: silent, -f: fail on HTTP errors, -L: follow redirects, -I: HEAD request only
   # --max-time: maximum time for the operation
   # --connect-timeout: maximum time for connection
-  if curl -s -f -L -I --connect-timeout "$timeout" --max-time "$timeout" "$url" >/dev/null 2>&1; then
-    echo "✓ OK"
-    return 0
-  else
-    echo "✗ FAILED"
-    CONNECTIVITY_OK=false
-    FAILED_SERVICES+=("$service_name")
-    return 1
-  fi
+  local max_retries=3
+  local attempt
+  for attempt in $(seq 1 $max_retries); do
+    if curl -s -f -L -I --connect-timeout "$timeout" --max-time "$timeout" "$url" >/dev/null 2>&1; then
+      echo "✓ OK"
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_retries" ]; then
+      echo -n "retry $((attempt + 1))/$max_retries... "
+      sleep 5
+    fi
+  done
+  echo "✗ FAILED"
+  CONNECTIVITY_OK=false
+  FAILED_SERVICES+=("$service_name")
+  return 1
 }
 
 # Check OpenShift Mirror (primary dependency for CRC download)
 check_service "OpenShift Mirror" "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/release.txt" 15
 
-# Check GitHub API (used for CRC version detection)
-check_service "GitHub API" "https://api.github.com" 10
+# Check GitHub API (used for CRC version detection, non-fatal since version
+# detection has its own fallback logic)
+check_service "GitHub API" "https://api.github.com" 10 || true
 
 echo ""
 echo "=== Connectivity Check Summary ==="

--- a/scripts/run-crc-setup.sh
+++ b/scripts/run-crc-setup.sh
@@ -28,7 +28,7 @@ while [ $attempt -le $max_attempts ]; do
     break
   fi
 
-  if echo "$start_output" | grep -qi "failed to update kubeconfig\|cannot update kubeconfig\|Failed to connect to the CRC VM with SSH"; then
+  if echo "$start_output" | grep -qi "failed to update kubeconfig\|cannot update kubeconfig\|Failed to connect to the CRC VM with SSH\|connection refused\|connection reset by peer"; then
     echo "WARNING: CRC start failed with retryable error (exit code $start_exit_code)"
     if [ $attempt -lt $max_attempts ]; then
       echo "Stopping CRC and retrying..."

--- a/scripts/scale-down-nonessential.sh
+++ b/scripts/scale-down-nonessential.sh
@@ -3,10 +3,18 @@ set -e
 
 echo "=== Disabling non-essential OpenShift operators ==="
 
-# Add ClusterVersion overrides so the CVO does not reconcile these back.
-# This mirrors the approach CRC uses to disable operators like monitoring.
-# We build the patch dynamically to skip operators already in the overrides list.
-EXISTING_OVERRIDES=$(oc get clusterversion/version -ojsonpath='{range .spec.overrides[*]}{.name}{"\n"}{end}')
+max_retries=5
+retry_delay=10
+for attempt in $(seq 1 $max_retries); do
+  EXISTING_OVERRIDES=$(oc get clusterversion/version -ojsonpath='{range .spec.overrides[*]}{.name}{"\n"}{end}' 2>&1) && break
+  echo "WARNING: Failed to query ClusterVersion (attempt $attempt/$max_retries), retrying in ${retry_delay}s..."
+  sleep "$retry_delay"
+  if [ "$attempt" -eq "$max_retries" ]; then
+    echo "ERROR: Could not reach ClusterVersion API after $max_retries attempts"
+    echo "$EXISTING_OVERRIDES"
+    exit 1
+  fi
+done
 
 PATCH="["
 NEED_COMMA=false

--- a/scripts/wait-for-node-ready.sh
+++ b/scripts/wait-for-node-ready.sh
@@ -21,6 +21,18 @@ while ! oc get nodes --request-timeout='30s' &>/dev/null; do
   elapsed=$((elapsed + interval))
   if [ $elapsed -ge $timeout ]; then
     echo "Timeout reached: Cluster not accessible after ${timeout}s"
+    echo ""
+    echo "=== CRC Status ==="
+    crc status 2>&1 || true
+    echo ""
+    echo "=== Memory Usage ==="
+    free -h 2>&1 || true
+    echo ""
+    echo "=== libvirt VM Status ==="
+    sudo virsh list --all 2>/dev/null || true
+    echo ""
+    echo "=== CRC Daemon Logs (last 30 lines) ==="
+    sudo journalctl -u "crc*" --no-pager -n 30 2>/dev/null || true
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary

Analysis of 8 failed nightly jobs across 6 runs (Jun 28 – Jul 16) identified three root causes of flakiness:

**Root Cause 1: CRC start not retrying on API server errors (2/8 failures)**
- CRC start failed with "Failed to update kubeadmin user password" and "Failed to update cluster ID" — both `connection refused` errors to `api.crc.testing:6443`
- The retry logic only matched kubeconfig and SSH errors, not these API server transients
- **Fix:** Added `connection refused` and `connection reset by peer` to the retryable error patterns in `run-crc-setup.sh`

**Root Cause 2: scale-down-nonessential.sh instant failure (1/8 failures)**
- `oc get clusterversion/version` hit a transient `connection reset by peer` and immediately exited due to `set -e`
- **Fix:** Added retry loop (5 attempts, 10s delay) for the ClusterVersion API query

**Root Cause 3: wait-for-node-ready.sh timeout with no diagnostics (5/8 failures)**
- Cluster API never became accessible within 900s — infrastructure flakiness on shared runners
- Timeout message gave no debugging context
- **Fix:** Added diagnostic dump on timeout (CRC status, memory usage, libvirt VM state, daemon logs)

## Test plan
- [ ] `make lint` passes
- [ ] CI passes on this PR
- [ ] Monitor next nightly runs for reduced flakiness