### PR TITLE
fix: prevent broken pipe from bypassing CRC start retry logic

### DIFF
--- a/scripts/check-connectivity.sh
+++ b/scripts/check-connectivity.sh
@@ -37,12 +37,36 @@ check_service() {
   return 1
 }
 
+# Non-fatal connectivity check (warns but does not fail the script)
+check_optional_service() {
+  local service_name="$1"
+  local url="$2"
+  local timeout="${3:-10}"
+
+  echo -n "Checking $service_name (optional)... "
+
+  local max_retries=5
+  local attempt
+  for attempt in $(seq 1 $max_retries); do
+    if curl -s -f -L -I --connect-timeout "$timeout" --max-time "$timeout" "$url" >/dev/null 2>&1; then
+      echo "✓ OK"
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_retries" ]; then
+      echo -n "retry $((attempt + 1))/$max_retries... "
+      sleep 5
+    fi
+  done
+  echo "✗ FAILED (non-fatal, continuing)"
+  return 0
+}
+
 # Check OpenShift Mirror (primary dependency for CRC download)
 check_service "OpenShift Mirror" "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/release.txt" 15
 
-# Check GitHub API (used for CRC version detection, non-fatal since version
+# Check GitHub API (used for CRC version detection — non-fatal since version
 # detection has its own fallback logic)
-check_service "GitHub API" "https://api.github.com" 10 || true
+check_optional_service "GitHub API" "https://api.github.com" 10
 
 echo ""
 echo "=== Connectivity Check Summary ==="

--- a/scripts/run-crc-setup.sh
+++ b/scripts/run-crc-setup.sh
@@ -22,13 +22,11 @@ while [ $attempt -le $max_attempts ]; do
   start_exit_code=0
   start_log="/tmp/crc-start-attempt-${attempt}.log"
   sudo -su "$USER" crc start --pull-secret-file pull-secret.json --log-level debug 2>&1 | tee "$start_log" || start_exit_code=$?
-  start_output=$(cat "$start_log")
-
   if [ $start_exit_code -eq 0 ]; then
     break
   fi
 
-  if echo "$start_output" | grep -qi "failed to update kubeconfig\|cannot update kubeconfig\|Failed to connect to the CRC VM with SSH\|connection refused\|connection reset by peer"; then
+  if grep -qi "failed to update kubeconfig\|cannot update kubeconfig\|Failed to connect to the CRC VM with SSH\|Failed to update pull secret\|connection refused\|connection reset by peer" "$start_log"; then
     echo "WARNING: CRC start failed with retryable error (exit code $start_exit_code)"
     if [ $attempt -lt $max_attempts ]; then
       echo "Stopping CRC and retrying..."


### PR DESCRIPTION
## Summary
- Fixed a bug where `echo "$start_output" | grep` caused a SIGPIPE under `set -eo pipefail`, killing the script before CRC start retries could execute. Replaced with `grep ... "$start_log"` to read the log file directly.
- Added `Failed to update pull secret` to retryable error patterns (seen in nightly run [29528128170](https://github.com/palmsoftware/quick-ocp/actions/runs/29528128170)).
- Removed unused `start_output` variable.

## Context
In the latest nightly run, 13/14 jobs passed. The single failure (`ubuntu-24.04, 4.21`) hit a retryable SSH error during CRC start, but the retry logic was bypassed because the pipe broke before the grep could complete. This fix ensures retries work correctly regardless of CRC output size.

## Test plan
- [ ] `make lint` passes
- [ ] Nightly run completes with improved retry reliability