### PR TITLE
security: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,14 +24,14 @@ jobs:
       SHELL: /bin/bash
     steps:
       - name: Check Red Hat Status
-        uses: palmsoftware/redhat-status@v0
+        uses: palmsoftware/redhat-status@a49265b8ca7eb95f4a09f3d01e01b66e72c35043 # v0
         with:
           components: |
             api.openshift.com
             developers.redhat.com
 
       - name: Checkout the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: check if OCP_PULL_SECRET exists
         env: 
@@ -55,14 +55,14 @@ jobs:
       SHELL: /bin/bash
     steps:
       - name: Check Red Hat Status
-        uses: palmsoftware/redhat-status@v0
+        uses: palmsoftware/redhat-status@a49265b8ca7eb95f4a09f3d01e01b66e72c35043 # v0
         with:
           components: |
             api.openshift.com
             developers.redhat.com
 
       - name: Checkout the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Deploy OCP with cluster monitoring enabled
         uses: ./
@@ -92,7 +92,7 @@ jobs:
       SHELL: /bin/bash
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Deploy OCP with preloaded images
         uses: ./

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Shfmt
         uses: mfinelli/setup-shfmt@a25fda4c1fe115aec0f85e04126610841bc3141d # v4.0.1
@@ -40,14 +40,14 @@ jobs:
       SHELL: /bin/bash
     steps:
       - name: Check Red Hat Status
-        uses: palmsoftware/redhat-status@v0
+        uses: palmsoftware/redhat-status@a49265b8ca7eb95f4a09f3d01e01b66e72c35043 # v0
         with:
           components: |
             api.openshift.com
             developers.redhat.com
 
       - name: Checkout the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: check if OCP_PULL_SECRET exists
         env:
@@ -73,14 +73,14 @@ jobs:
       SHELL: /bin/bash
     steps:
       - name: Check Red Hat Status
-        uses: palmsoftware/redhat-status@v0
+        uses: palmsoftware/redhat-status@a49265b8ca7eb95f4a09f3d01e01b66e72c35043 # v0
         with:
           components: |
             api.openshift.com
             developers.redhat.com
 
       - name: Checkout the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Deploy OCP with cluster monitoring enabled
         uses: ./
@@ -112,7 +112,7 @@ jobs:
       SHELL: /bin/bash
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Deploy OCP with preloaded images
         uses: ./

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 

--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
       run: ${{ github.action_path }}/scripts/get-ocp-version.sh
 
     - name: Restore CRC bundles from the cache
-      uses: actions/cache/restore@v6
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       if: ${{ inputs.bundleCache == 'true' }}
       id: restore-cache
       with:
@@ -168,7 +168,7 @@ runs:
       run: ${{ github.action_path }}/scripts/create-swap.sh
 
     - name: Optimize disk space and relocate Docker storage
-      uses: palmsoftware/quick-cleanup@v0
+      uses: palmsoftware/quick-cleanup@e0fa8042229eafe51f8519203e72439142066bb3 # v0
       with:
         cleanup-mode: aggressive
         minimum-free-space: 25
@@ -228,7 +228,7 @@ runs:
       run: ${{ github.action_path }}/scripts/move-crc-bundles-to-temp.sh
 
     - name: Cache the crc bundles using github actions cache
-      uses: actions/cache/save@v6
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       if: ${{ inputs.bundleCache == 'true' && steps.restore-cache.outputs.cache-hit != 'true' }}
       with:
         path: ~/.crc/bundletmp


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions references to immutable commit SHAs across `action.yml` and all workflow files
- Prevents a compromised tag from injecting code into pipelines
- Each pin includes a version comment for readability (e.g., `@9c091bb...  # v7`)
- Follows existing pattern from `mfinelli/setup-shfmt` in pre-main.yml

## Actions pinned
- `actions/checkout@v7` (8 references)
- `actions/cache/restore@v6` and `actions/cache/save@v6` (2 references)
- `palmsoftware/quick-cleanup@v0` (1 reference)
- `palmsoftware/redhat-status@v0` (4 references)

Closes #89

## Test plan
- [ ] `make lint` passes
- [ ] CI integration tests pass with SHA-pinned actions