### PR TITLE
security: add SHA256 checksum verification for CRC download

### DIFF
--- a/scripts/download-install-crc.sh
+++ b/scripts/download-install-crc.sh
@@ -25,15 +25,32 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   # Remove any partial download from previous attempt
   rm -f crc.tar.xz
 
-  if curl -L -o crc.tar.xz "https://mirror.openshift.com/pub/openshift-v4/clients/crc/$CRC_VERSION/crc-linux-$CRC_ARCH.tar.xz"; then
-    # Verify the downloaded file is valid (should be larger than 1MB)
+  MIRROR_BASE="https://mirror.openshift.com/pub/openshift-v4/clients/crc/$CRC_VERSION"
+  CRC_FILENAME="crc-linux-$CRC_ARCH.tar.xz"
+
+  if curl -L -o crc.tar.xz "$MIRROR_BASE/$CRC_FILENAME"; then
     FILE_SIZE=$(stat -c%s crc.tar.xz 2>/dev/null || stat -f%z crc.tar.xz 2>/dev/null || echo 0)
-    if [ "$FILE_SIZE" -gt 1048576 ]; then
-      echo "Download successful. File size: $FILE_SIZE bytes"
+    if [ "$FILE_SIZE" -le 1048576 ]; then
+      echo "Download failed: File too small ($FILE_SIZE bytes), likely an error page"
+    elif curl -sL -o sha256sum.txt "$MIRROR_BASE/sha256sum.txt"; then
+      EXPECTED=$(grep "$CRC_FILENAME" sha256sum.txt | awk '{print $1}')
+      if [ -z "$EXPECTED" ]; then
+        echo "WARNING: No checksum found for $CRC_FILENAME in sha256sum.txt, skipping verification"
+        DOWNLOAD_SUCCESS=true
+        break
+      fi
+      ACTUAL=$(sha256sum crc.tar.xz | awk '{print $1}')
+      if [ "$EXPECTED" = "$ACTUAL" ]; then
+        echo "Download successful. File size: $FILE_SIZE bytes, SHA256 verified"
+        DOWNLOAD_SUCCESS=true
+        break
+      else
+        echo "SHA256 mismatch: expected $EXPECTED, got $ACTUAL"
+      fi
+    else
+      echo "WARNING: Could not download sha256sum.txt, skipping verification"
       DOWNLOAD_SUCCESS=true
       break
-    else
-      echo "Download failed: File too small ($FILE_SIZE bytes), likely an error page"
     fi
   else
     echo "Download failed with curl error"
@@ -60,6 +77,6 @@ else
   exit 1
 fi
 # Clean up immediately after extraction
-rm -rf crc.tar.xz crc-linux-*
+rm -rf crc.tar.xz crc-linux-* sha256sum.txt
 echo "=== Disk usage after CRC download ==="
 df -h


### PR DESCRIPTION
## Summary
- Verify CRC binary downloads against the published `sha256sum.txt` from the OpenShift mirror
- A SHA256 mismatch is treated as a download failure and triggers a retry
- Falls back gracefully if `sha256sum.txt` is unavailable or missing an entry

## Changes
The download validation in `scripts/download-install-crc.sh` now:
1. Downloads `sha256sum.txt` from the same mirror directory
2. Extracts the expected hash for `crc-linux-{arch}.tar.xz`
3. Computes `sha256sum` of the downloaded file
4. Compares — mismatch triggers retry, match logs "SHA256 verified"

The file size check is retained as a fast pre-filter before the slower SHA256 computation.

Closes #70

## Test plan
- [ ] `make lint` passes
- [ ] CI integration tests pass (SHA256 verification runs during CRC download step)