### PR TITLE
fix: authenticate GitHub API calls to avoid rate limiting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,6 +112,8 @@ runs:
     - name: Set CRC version variable
       id: set_crc_version
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: ${{ github.action_path }}/scripts/set-crc-version.sh "${{ inputs.desiredOCPVersion }}" "${{ github.action_path }}" "${{ inputs.crcVersion }}"
 
     - name: Download and Install OpenShift Local Binary

--- a/scripts/fetch-ocp-crc-version.sh
+++ b/scripts/fetch-ocp-crc-version.sh
@@ -17,10 +17,19 @@ if ! [[ "$OCP_VERSION" =~ ^4\.(1[8-9]|[2-9][0-9])$ ]]; then
   exit 2
 fi
 
+# Build auth header if GITHUB_TOKEN is available (raises rate limit from 60 to 5000 req/hr)
+AUTH_HEADER=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  echo "Using authenticated GitHub API request" >&2
+else
+  echo "WARNING: GITHUB_TOKEN not set, using unauthenticated API (60 req/hr limit)" >&2
+fi
+
 # Retry curl up to 10 times with 3s delay
 RETRIES=10
 for i in $(seq 1 $RETRIES); do
-  RESPONSE=$(curl -s -H "Accept: application/vnd.github.v3+json" "$GITHUB_API") || true
+  RESPONSE=$(curl -s -H "Accept: application/vnd.github.v3+json" "${AUTH_HEADER[@]}" "$GITHUB_API") || true
   # Check if response is valid JSON and not empty
   if [ -n "$RESPONSE" ] && echo "$RESPONSE" | jq empty >/dev/null 2>&1; then
     break


### PR DESCRIPTION
## Summary

- Pass `GITHUB_TOKEN` as Bearer header in `fetch-ocp-crc-version.sh` to raise the GitHub API rate limit from 60 to 5,000 requests/hour
- Add `GITHUB_TOKEN` env var to the `set-crc-version` step in `action.yml` using `github.token`
- Graceful fallback: logs a warning if token is unavailable and continues unauthenticated

Closes #74