### PR TITLE
perf: consolidate duplicate package installation

### DIFF
--- a/scripts/enable-kvm-perms.sh
+++ b/scripts/enable-kvm-perms.sh
@@ -8,7 +8,6 @@ sudo udevadm trigger --name-match=kvm
 sudo udevadm trigger --name-match=vhost-vsock 2>/dev/null || true
 sudo chmod 0666 /dev/kvm 2>/dev/null || true
 sudo chmod 0666 /dev/vhost-vsock 2>/dev/null || true
-sudo apt-get install -y libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils qemu-system-x86
 sudo usermod -a -G kvm,libvirt "$USER"
 if ! groups "$USER" | grep -q libvirt; then
   sudo adduser "$(id -un)" libvirt

--- a/scripts/install-ubuntu-dependencies.sh
+++ b/scripts/install-ubuntu-dependencies.sh
@@ -3,14 +3,17 @@ set -e
 
 UBUNTU_VERSION=$(lsb_release -rs)
 echo "Detected Ubuntu version: $UBUNTU_VERSION"
+
+COMMON_PACKAGES=(libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils qemu-system-x86)
+
+sudo apt-get update
+
 if [[ "$UBUNTU_VERSION" == "22.04" ]]; then
-  echo "Installing specific dependencies for Ubuntu 22.04"
-  sudo apt-get update
-  sudo apt-get install -y qemu
+  echo "Installing dependencies for Ubuntu 22.04"
+  sudo apt-get install -y "${COMMON_PACKAGES[@]}" qemu
 elif [[ "$UBUNTU_VERSION" == "24.04" ]]; then
-  echo "Installing specific dependencies for Ubuntu 24.04"
-  sudo apt-get update
-  sudo apt-get install -y virtiofsd libvirt-daemon-system libvirt-daemon-driver-qemu
+  echo "Installing dependencies for Ubuntu 24.04"
+  sudo apt-get install -y "${COMMON_PACKAGES[@]}" virtiofsd libvirt-daemon-driver-qemu
   if systemctl list-unit-files | grep -q virtqemud.socket; then
     sudo systemctl enable virtqemud.socket
     sudo systemctl start virtqemud.socket
@@ -18,14 +21,14 @@ elif [[ "$UBUNTU_VERSION" == "24.04" ]]; then
     echo "virtqemud.socket unit file does not exist. Skipping enable/start steps."
   fi
 elif [[ "$UBUNTU_VERSION" == "26.04" ]]; then
-  echo "Installing specific dependencies for Ubuntu 26.04"
-  sudo apt-get update
-  sudo apt-get install -y virtiofsd libvirt-daemon-system libvirt-daemon-driver-qemu qemu-system-x86
+  echo "Installing dependencies for Ubuntu 26.04"
+  sudo apt-get install -y "${COMMON_PACKAGES[@]}" virtiofsd libvirt-daemon-driver-qemu
   if systemctl list-unit-files | grep -q libvirtd.socket; then
     sudo systemctl enable libvirtd.socket
     sudo systemctl start libvirtd.socket
   fi
   sudo modprobe vhost_vsock || true
 else
-  echo "No specific dependencies for Ubuntu version $UBUNTU_VERSION"
+  echo "Installing base dependencies for Ubuntu $UBUNTU_VERSION"
+  sudo apt-get install -y "${COMMON_PACKAGES[@]}"
 fi


### PR DESCRIPTION
## Summary

- Move common libvirt/qemu packages (`libvirt-clients`, `libvirt-daemon-system`, `libvirt-daemon`, `virtinst`, `bridge-utils`, `qemu-system-x86`) from `enable-kvm-perms.sh` into `install-ubuntu-dependencies.sh`
- Eliminates duplicate `apt-get install` calls across two scripts
- Fixes missing `apt-get update` in `enable-kvm-perms.sh` which could cause stale package index failures
- Single `apt-get update` + `apt-get install` per run instead of two

Closes #79