### PR TITLE
ci: add ubuntu-26.04 support to CI matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-22.04]
         ocp: ['4.18', '4.19', '4.20', '4.21', '4.22', 'latest']
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -33,11 +33,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-22.04]
         ocp: ['4.18', '4.19', '4.20', '4.21', '4.22', 'latest']
-        include:
-          - os: ubuntu-26.04
-            ocp: 'latest'
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -35,6 +35,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
         ocp: ['4.18', '4.19', '4.20', '4.21', '4.22', 'latest']
+        include:
+          - os: ubuntu-26.04
+            ocp: 'latest'
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ If you are looking to quickly spawn Kubernetes in your Action runner, try [quick
 
 This action is tested on the following GitHub Actions runners:
 
+- `ubuntu-26.04`
 - `ubuntu-24.04`
 - `ubuntu-22.04`
 
 # Known Limitations:
 
-- `ubuntu-26.04` is not yet supported due to a CRC vsock SSH incompatibility with Linux kernel 7.0. See [crc-org/crc#5283](https://github.com/crc-org/crc/issues/5283) for tracking.
 - `ubuntu-20.04` is not supported due to the version of `libvirt` available in the mirrors not meeting the minimum version required by OpenShift Local.
 
 # Connectivity Requirements:


### PR DESCRIPTION
## Summary
- Add ubuntu-26.04 to pre-main and nightly CI matrices across all OCP versions
- Update README to list ubuntu-26.04 as a supported runner
- Remove the known limitation note about vsock SSH incompatibility

## Context
CRC upstream's OKD CI test has been consistently passing on ubuntu-26.04 runners (kernel 7.0.0-1009-azure) with vsock network mode. Our own test with OCP `latest` on ubuntu-26.04 also passed (PR CI first run). The vsock accept queue leak (CVE-2026-46214) appears to not be triggered by current CRC/bundle versions on these runners.

Tracking issue: crc-org/crc#5283

## Test plan
- [ ] All ubuntu-26.04 matrix jobs pass (OCP 4.18-4.22 + latest)
- [ ] Existing ubuntu-24.04 and ubuntu-22.04 jobs unaffected
- [ ] Nightly workflow includes ubuntu-26.04