### PR TITLE
Add resource precheck before deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ steps:
 | `enableClusterMonitoring` | Enable the cluster monitoring stack (auto-increases memory to 14GiB) | No | `false` |
 | `enableTelemetry` | Enable telemetry for OpenShift Local | No | `true` |
 | `disableConnectivityCheck` | Disable the connectivity check for OpenShift Mirror | No | `false` |
+| `disableResourcePrecheck` | Disable the resource precheck (CPU, memory, disk capacity validation) | No | `false` |
 | `preloadImages` | Newline-separated list of container images to preload into the cluster registry | No | — |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Disable the connectivity check for OpenShift Mirror'
     required: false
     default: 'false'
+  disableResourcePrecheck:
+    description: 'Disable the resource precheck (CPU, memory, disk capacity validation)'
+    required: false
+    default: 'false'
   enableClusterMonitoring:
     description: 'Enable the cluster monitoring stack (requires minimum 14GiB memory)'
     required: false
@@ -103,6 +107,11 @@ runs:
       id: deployment_start
       shell: bash
       run: echo "start_time=$(date +%s)" >>"${GITHUB_OUTPUT}"
+
+    - name: Precheck runner resources
+      if: ${{ inputs.disableResourcePrecheck != 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/precheck-resources.sh "${{ inputs.crcCpu }}" "${{ inputs.crcMemory }}" "${{ inputs.enableClusterMonitoring }}"
 
     - name: Check connectivity to required services
       if: ${{ inputs.disableConnectivityCheck != 'true' }}

--- a/scripts/precheck-resources.sh
+++ b/scripts/precheck-resources.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -e
+
+CRC_CPU="$1"
+CRC_MEMORY="$2"
+ENABLE_CLUSTER_MONITORING="$3"
+
+echo "=== Prechecking runner resources for CRC deployment ==="
+
+# Keep in sync with configure-crc.sh
+MIN_MONITORING_MEMORY=14336
+if [ "$ENABLE_CLUSTER_MONITORING" = "true" ]; then
+  if [ "$CRC_MEMORY" -lt "$MIN_MONITORING_MEMORY" ]; then
+    CRC_MEMORY=$MIN_MONITORING_MEMORY
+  fi
+fi
+
+MIN_TOTAL_DISK_GB=50
+CRITICAL_MEMORY_MB=4096
+
+PRECHECK_OK=true
+FAILED_CHECKS=()
+WARNINGS=()
+
+check_cpu() {
+  local required="$1"
+  local available
+  available=$(nproc)
+
+  echo -n "Checking CPU count... "
+  if [ "$available" -lt "$required" ]; then
+    echo "✗ FAILED ($available available, $required required)"
+    PRECHECK_OK=false
+    FAILED_CHECKS+=("CPU: runner has $available CPUs but CRC requires $required")
+  else
+    echo "✓ OK ($available available, $required required)"
+  fi
+}
+
+check_memory() {
+  local required="$1"
+  local total_mb
+  total_mb=$(awk '/MemTotal/{printf "%d", $2/1024}' /proc/meminfo)
+
+  echo -n "Checking memory... "
+  if [ "$total_mb" -lt "$CRITICAL_MEMORY_MB" ]; then
+    echo "✗ FAILED (${total_mb}MB available, minimum ${CRITICAL_MEMORY_MB}MB)"
+    PRECHECK_OK=false
+    FAILED_CHECKS+=("Memory: runner has ${total_mb}MB RAM which is below the ${CRITICAL_MEMORY_MB}MB minimum (even with swap)")
+  elif [ "$total_mb" -lt "$required" ]; then
+    echo "✓ OK with warning (${total_mb}MB physical, ${required}MB requested)"
+    WARNINGS+=("Memory: runner has ${total_mb}MB physical RAM but CRC will request ${required}MB. The action creates 8GB swap to compensate, but expect slower performance.")
+  else
+    echo "✓ OK (${total_mb}MB available, ${required}MB requested)"
+  fi
+}
+
+check_mnt_directory() {
+  echo -n "Checking /mnt directory... "
+  if [ ! -d /mnt ]; then
+    echo "✗ FAILED (/mnt does not exist)"
+    PRECHECK_OK=false
+    FAILED_CHECKS+=("/mnt: directory does not exist. CRC storage, swap, and Docker are relocated to /mnt. Standard GitHub runners provide this; self-hosted runners may need to create /mnt.")
+  elif ! sudo touch /mnt/.precheck-test 2>/dev/null; then
+    echo "✗ FAILED (/mnt is not writable)"
+    PRECHECK_OK=false
+    FAILED_CHECKS+=("/mnt: directory exists but is not writable. CRC storage, swap, and Docker are relocated to /mnt and require write access.")
+  else
+    sudo rm -f /mnt/.precheck-test
+    echo "✓ OK"
+  fi
+}
+
+check_disk_capacity() {
+  local min_total="$1"
+  local root_total_gb mnt_total_gb total_gb
+  local root_device mnt_device
+
+  root_total_gb=$(df --output=size -BG / | tail -1 | tr -d 'G ')
+  root_device=$(df --output=source / | tail -1)
+
+  mnt_total_gb=0
+  if [ -d /mnt ]; then
+    mnt_device=$(df --output=source /mnt 2>/dev/null | tail -1)
+    if [ "$mnt_device" != "$root_device" ]; then
+      mnt_total_gb=$(df --output=size -BG /mnt | tail -1 | tr -d 'G ')
+    fi
+  fi
+
+  total_gb=$((root_total_gb + mnt_total_gb))
+
+  echo -n "Checking total disk capacity... "
+  if [ "$total_gb" -lt "$min_total" ]; then
+    echo "✗ FAILED (${total_gb}GB total, ${min_total}GB minimum)"
+    PRECHECK_OK=false
+    FAILED_CHECKS+=("Disk: combined root + /mnt capacity is ${total_gb}GB but at least ${min_total}GB is required (root: ${root_total_gb}GB, /mnt: ${mnt_total_gb}GB)")
+  else
+    echo "✓ OK (${total_gb}GB total across root: ${root_total_gb}GB, /mnt: ${mnt_total_gb}GB)"
+  fi
+}
+
+check_cpu "$CRC_CPU"
+check_memory "$CRC_MEMORY"
+check_mnt_directory
+check_disk_capacity "$MIN_TOTAL_DISK_GB"
+
+echo ""
+echo "=== Resource Precheck Summary ==="
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+  for warning in "${WARNINGS[@]}"; do
+    echo "WARNING: $warning"
+  done
+  echo ""
+fi
+
+if [ "$PRECHECK_OK" = true ]; then
+  echo "✓ All resource prechecks passed"
+  echo ""
+  exit 0
+else
+  echo "✗ Resource precheck FAILED"
+  echo ""
+  echo "The following requirements are not met:"
+  for check in "${FAILED_CHECKS[@]}"; do
+    echo "  - $check"
+  done
+  echo ""
+  echo "Suggestions:"
+  echo "  - Use a GitHub-hosted runner with more resources"
+  echo "  - Reduce resource requests via crcCpu, crcMemory, or crcDiskSize inputs"
+  echo "  - Set disableResourcePrecheck: true to skip this check (not recommended)"
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/precheck-resources.sh` that validates runner resources before attempting CRC deployment
- Checks CPU count, physical memory, /mnt partition presence, and total disk capacity
- Fails fast with actionable error messages instead of waiting 5-15 minutes for setup to fail
- New `disableResourcePrecheck` input to skip the check if needed

## Design decisions

- **Checks total disk capacity, not free space.** The quick-cleanup step runs later and frees 15-30 GB. Checking free space before cleanup would produce false failures on every run. Total capacity is immutable and tells us whether cleanup can plausibly succeed (threshold: 50 GB combined root + /mnt).
- **Memory is a warning, not a hard failure** (except below 4096 MB). The action creates 8 GB swap and many successful deployments run with less physical RAM than the `crcMemory` setting. Applies the same monitoring memory bump (14336 MB) as `configure-crc.sh` when `enableClusterMonitoring: true`.
- **Follows `check-connectivity.sh` pattern** — runs all checks, collects failures/warnings, and reports a summary.

## Test plan

- [ ] `make lint` passes (shfmt + shellcheck)
- [ ] CI passes on ubuntu-22.04, ubuntu-24.04, ubuntu-26.04 without false positives
- [ ] Precheck step appears in job logs with pass/warning/fail output

Closes #123