### PR TITLE
ux: validate pull secret JSON format before writing

### DIFF
--- a/scripts/write-pull-secret.sh
+++ b/scripts/write-pull-secret.sh
@@ -6,4 +6,14 @@ if [ -z "$PULL_SECRET" ]; then
   exit 1
 fi
 
+if ! echo "$PULL_SECRET" | jq empty 2>/dev/null; then
+  echo "[ERROR] PULL_SECRET is not valid JSON. Verify the secret value in your repository settings." >&2
+  exit 1
+fi
+
+if ! echo "$PULL_SECRET" | jq -e '.auths | length > 0' >/dev/null 2>&1; then
+  echo "[ERROR] PULL_SECRET does not contain registry credentials (.auths is missing or empty)." >&2
+  exit 1
+fi
+
 (umask 077 && echo "$PULL_SECRET" >pull-secret.json)


### PR DESCRIPTION
## Summary
- Add `jq empty` validation to catch malformed JSON pull secrets before writing to disk
- Add `.auths` key validation to ensure the pull secret contains registry credentials
- Fail fast with clear error messages instead of letting CRC discover invalid secrets 10+ minutes into setup

## Test plan
- [ ] Verify `PULL_SECRET=""` still produces the existing "not set" error
- [ ] Verify `PULL_SECRET="not json"` produces the new "not valid JSON" error
- [ ] Verify `PULL_SECRET="{}"` produces the new ".auths is missing or empty" error
- [ ] Verify a valid pull secret writes successfully to `pull-secret.json`
- [ ] CI pre-main passes with real pull secret

Closes #124