### PR TITLE
ux: improve pull secret missing error message

### DIFF
--- a/scripts/write-pull-secret.sh
+++ b/scripts/write-pull-secret.sh
@@ -3,6 +3,9 @@ set -e
 
 if [ -z "$PULL_SECRET" ]; then
   echo "[ERROR] PULL_SECRET environment variable is not set." >&2
+  echo "  Hint: Set the ocpPullSecret input using \${{ secrets.OCP_PULL_SECRET }} in your workflow." >&2
+  echo "  If the secret is not created, add it at: Settings > Secrets and variables > Actions." >&2
+  echo "  Pull secrets can be obtained from https://console.redhat.com/openshift/create/local." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add actionable hints when PULL_SECRET is empty: how to set the workflow input, where to create the repository secret, and where to obtain a pull secret from Red Hat
- Catches the most common onboarding mistake (using `$OCP_PULL_SECRET` literally instead of `${{ secrets.OCP_PULL_SECRET }}`)

## Test plan
- [ ] Verify empty PULL_SECRET shows the new hint lines alongside the existing error
- [ ] Verify a valid PULL_SECRET still writes successfully
- [ ] CI pre-main passes

Closes #152