### PR TITLE
ux: log full CRC download URL for debugging

### DIFF
--- a/scripts/download-install-crc.sh
+++ b/scripts/download-install-crc.sh
@@ -27,6 +27,7 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
 
   MIRROR_BASE="https://mirror.openshift.com/pub/openshift-v4/clients/crc/$CRC_VERSION"
   CRC_FILENAME="crc-linux-$CRC_ARCH.tar.xz"
+  echo "Download URL: $MIRROR_BASE/$CRC_FILENAME"
 
   if curl -L -o crc.tar.xz "$MIRROR_BASE/$CRC_FILENAME"; then
     FILE_SIZE=$(stat -c%s crc.tar.xz 2>/dev/null || stat -f%z crc.tar.xz 2>/dev/null || echo 0)


### PR DESCRIPTION
## Summary
- Print the complete mirror URL before each download attempt
- When downloads fail, users can copy the URL directly to test manually instead of reconstructing it from variables

## Test plan
- [ ] Verify the full URL appears in CI logs before each download attempt
- [ ] CI pre-main passes

Closes #153