### PR TITLE
ux: report which operators are pending during wait loop

### DIFF
--- a/scripts/wait-for-operators.sh
+++ b/scripts/wait-for-operators.sh
@@ -10,11 +10,15 @@ elapsed=0
 interval=10
 
 while true; do
-  if oc get co --no-headers | awk '{if ($3 != "True" || $4 != "False" || $5 != "False") exit 1}'; then
+  co_status=$(oc get co --no-headers)
+  not_ready=$(echo "$co_status" | awk '$3 != "True" || $4 != "False" || $5 != "False" {print "  " $1, "Available="$3, "Progressing="$4, "Degraded="$5}')
+
+  if [ -z "$not_ready" ]; then
     echo "All operators are available, not progressing, and not degraded"
     break
   else
-    echo "Waiting for operators to become available..."
+    echo "Waiting for operators to become available... (${elapsed}s/${timeout}s)"
+    echo "$not_ready"
     sleep "$interval"
     elapsed=$((elapsed + interval))
     if [ "$elapsed" -ge "$timeout" ]; then


### PR DESCRIPTION
## Summary
- Show which operators are not ready on each polling iteration with their Available/Progressing/Degraded status
- Add elapsed time progress indicator (`Xs/Ys`) to the waiting message
- Capture `oc get co` output once per iteration (avoiding duplicate API calls) and derive both the readiness check and the status report from it

## Test plan
- [ ] Verify each wait iteration shows the names and status of not-ready operators
- [ ] Verify elapsed time counter increments correctly
- [ ] Verify "All operators are available" message appears when all operators are ready
- [ ] Verify timeout still dumps full `oc get co` status
- [ ] CI pre-main passes

Closes #149