### PR TITLE
ux: validate desiredOCPVersion input early before setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,22 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/precheck-resources.sh "${{ inputs.crcCpu }}" "${{ inputs.crcMemory }}" "${{ inputs.enableClusterMonitoring }}"
 
+    - name: Validate desiredOCPVersion input
+      shell: bash
+      run: |
+        VERSION="${{ inputs.desiredOCPVersion }}"
+        # Normalize YAML float parsing (4.2 -> 4.20)
+        if [[ "$VERSION" =~ ^4\.([0-9]+)$ ]]; then
+          MINOR="${BASH_REMATCH[1]}"
+          if [ ${#MINOR} -eq 1 ] && [ "$MINOR" -ge 2 ]; then
+            VERSION="4.${MINOR}0"
+          fi
+        fi
+        if [ "$VERSION" != "latest" ] && [[ ! "$VERSION" =~ ^4\.(1[8-9]|[2-9][0-9])$ ]]; then
+          echo "[ERROR] Invalid desiredOCPVersion: '${{ inputs.desiredOCPVersion }}'. Supported values are 4.18 and above, or 'latest'." >&2
+          exit 1
+        fi
+
     - name: Check connectivity to required services
       if: ${{ inputs.disableConnectivityCheck != 'true' }}
       shell: bash


### PR DESCRIPTION
## Summary
- Add early validation step in action.yml that runs before connectivity checks and CRC setup
- Rejects invalid OCP versions (e.g., `3.11`, `foo`) immediately with a clear error message
- Includes YAML float normalization (`4.2` -> `4.20`) so versions affected by YAML parsing still pass validation
- Prevents wasting CI time on connectivity checks and setup for an invalid version

## Test plan
- [ ] Verify `desiredOCPVersion: "3.11"` fails immediately with the validation error
- [ ] Verify `desiredOCPVersion: "foo"` fails immediately with the validation error
- [ ] Verify `desiredOCPVersion: "4.19"` passes validation
- [ ] Verify `desiredOCPVersion: "4.20"` passes validation (YAML float normalization)
- [ ] Verify `desiredOCPVersion: "latest"` passes validation
- [ ] CI pre-main passes

Closes #141