### PR TITLE
ux: add elapsed time progress indicators to wait loops

### DIFF
--- a/scripts/preload-images.sh
+++ b/scripts/preload-images.sh
@@ -21,6 +21,7 @@ echo "Waiting for image registry route..."
 timeout=120
 elapsed=0
 while ! oc get route default-route -n openshift-image-registry &>/dev/null; do
+  echo "Waiting for image registry route... (${elapsed}s/${timeout}s)"
   sleep 5
   elapsed=$((elapsed + 5))
   if [ $elapsed -ge $timeout ]; then

--- a/scripts/wait-for-node-ready.sh
+++ b/scripts/wait-for-node-ready.sh
@@ -16,7 +16,7 @@ curl -sk --connect-timeout 5 https://api.crc.testing:6443 2>&1 | head -3 || true
 # Wait for cluster to be ready and accessible
 echo "Waiting for cluster to be accessible..."
 while ! oc get nodes --request-timeout='30s' &>/dev/null; do
-  echo "Cluster not yet accessible, waiting..."
+  echo "Cluster not yet accessible, waiting... (${elapsed}s/${timeout}s)"
   sleep $interval
   elapsed=$((elapsed + interval))
   if [ $elapsed -ge $timeout ]; then
@@ -39,7 +39,7 @@ done
 
 # Wait for the node to be in Ready state
 while [[ $(oc get nodes --request-timeout='30s' -o json | jq -r '.items[] | select(.metadata.name=="api.crc.testing") | .status.conditions[] | select(.reason=="KubeletReady") | .status') == "False" ]]; do
-  echo "Waiting for node to be in Ready state"
+  echo "Waiting for node to be in Ready state... (${elapsed}s/${timeout}s)"
   sleep 5
   elapsed=$((elapsed + 5))
   if [ $elapsed -ge $timeout ]; then


### PR DESCRIPTION
## Summary
- Add `(Xs/Ys)` elapsed/timeout indicators to wait messages in `wait-for-node-ready.sh` and `preload-images.sh`
- Covers cluster accessibility wait, KubeletReady wait, and image registry route wait
- Uses existing `elapsed` and `timeout` variables already tracked by these scripts

Note: `wait-for-operators.sh` elapsed time is handled separately in #161.

## Test plan
- [ ] Verify elapsed time appears in cluster accessibility wait messages
- [ ] Verify elapsed time appears in node ready wait messages
- [ ] Verify elapsed time appears in image registry route wait messages
- [ ] Verify counters increment correctly on each iteration
- [ ] CI pre-main passes

Closes #136