### PR TITLE
ux: improve preload-images error messages with inline stderr

### DIFF
--- a/scripts/preload-images.sh
+++ b/scripts/preload-images.sh
@@ -62,15 +62,21 @@ while IFS= read -r IMAGE; do
 
   echo "--- Mirroring: $IMAGE -> $REGISTRY/openshift/$IMAGE_NAME ---"
 
-  if oc image mirror \
+  mirror_output=$(oc image mirror \
     "$IMAGE" \
     "$REGISTRY/openshift/$IMAGE_NAME" \
     --insecure=true \
-    --keep-manifest-list=true 2>&1; then
+    --keep-manifest-list=true 2>&1) && mirror_rc=0 || mirror_rc=$?
+
+  if [ "$mirror_rc" -eq 0 ]; then
     echo "OK: $IMAGE"
     SUCCESS=$((SUCCESS + 1))
   else
+    mirror_error=$(echo "$mirror_output" | grep -i "error" | tail -3)
     echo "FAILED: $IMAGE"
+    if [ -n "$mirror_error" ]; then
+      echo "$mirror_error"
+    fi
     FAILED=$((FAILED + 1))
     FAILED_IMAGES="$FAILED_IMAGES  - $IMAGE\n"
   fi


### PR DESCRIPTION
## Summary
- Capture `oc image mirror` output instead of streaming it directly
- On failure, extract and display the last 3 error lines immediately alongside the `FAILED:` message
- Eliminates the need to scroll back through grouped log output to find the root cause of mirror failures

## Test plan
- [ ] Verify successful image mirrors still show `OK:` messages
- [ ] Verify failed image mirrors show `FAILED:` followed by the relevant error lines
- [ ] Verify the failure summary at the end still lists all failed images
- [ ] CI pre-main passes

Closes #135