### PR TITLE
fix: address 5 shell script bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Lines starting with `#` and blank lines are ignored, so you can comment your ima
 **Mitigations:**
 - The action automatically creates swap on `/mnt` and protects CRC/QEMU processes from the OOM killer.
 - Use `bundleCache: true` to avoid downloading the 3-5 GB bundle during the job, freeing memory during the critical startup window.
-- Reduce `crcMemory` if your tests don't need the full allocation (minimum ~9216 MB for a functional cluster).
+- Reduce `crcMemory` if your tests don't need the full allocation (minimum 10752 MB, which is CRC's recommended minimum).
 - Avoid running memory-intensive steps before `crc start` completes.
 
 ### Disk Space Exhaustion

--- a/scripts/copy-bundletmp-to-cache.sh
+++ b/scripts/copy-bundletmp-to-cache.sh
@@ -4,6 +4,27 @@ set -e
 mkdir -p "$HOME/.crc/cache"
 if [ -d "$HOME/.crc/bundletmp" ] && [ "$(ls -A "$HOME/.crc/bundletmp" 2>/dev/null)" ]; then
   cp -r "$HOME/.crc/bundletmp"/* "$HOME/.crc/cache/"
+
+  min_size=$((1024 * 1024 * 1024))
+  bundle_ok=true
+  found_bundle=false
+  for bundle in "$HOME/.crc/cache"/*.crcbundle; do
+    [ -e "$bundle" ] || continue
+    found_bundle=true
+    file_size=$(stat --format='%s' "$bundle" 2>/dev/null || stat -f '%z' "$bundle" 2>/dev/null || echo 0)
+    if [ "$file_size" -lt "$min_size" ]; then
+      echo "WARNING: Bundle $(basename "$bundle") is only $((file_size / 1024 / 1024))MB, expected at least 1024MB. Removing."
+      rm -f "$bundle"
+      bundle_ok=false
+    fi
+  done
+  if [ "$found_bundle" = false ]; then
+    echo "WARNING: No .crcbundle files found in cache after copy. Fresh download will be triggered."
+  elif [ "$bundle_ok" = false ]; then
+    echo "WARNING: Corrupt bundle(s) removed. Fresh download will be triggered."
+  else
+    echo "Bundle cache integrity verified."
+  fi
 else
   echo "No files found in bundletmp to copy or directory does not exist"
 fi

--- a/scripts/create-swap.sh
+++ b/scripts/create-swap.sh
@@ -3,13 +3,21 @@ set -e
 
 echo "=== Ensuring swap exists on /mnt ==="
 SWAPFILE="/mnt/swapfile"
-# Create a ~8G swapfile if no swap is active
+SWAP_SIZE_GB=8
+SWAP_SIZE_MB=$((SWAP_SIZE_GB * 1024))
+SWAP_SIZE_KB=$((SWAP_SIZE_MB * 1024))
 if ! sudo swapon --show | grep -q "."; then
-  echo "No active swap detected; creating ${SWAPFILE}"
-  sudo fallocate -l 8G "$SWAPFILE" || sudo dd if=/dev/zero of="$SWAPFILE" bs=1M count=8192
-  sudo chmod 600 "$SWAPFILE"
-  sudo mkswap "$SWAPFILE"
-  sudo swapon "$SWAPFILE"
+  echo "No active swap detected; creating ${SWAP_SIZE_GB}G swapfile at ${SWAPFILE}"
+  avail_kb=$(df --output=avail /mnt 2>/dev/null | tail -1 | tr -d ' ')
+  if [ -z "$avail_kb" ] || [ "$avail_kb" -lt "$SWAP_SIZE_KB" ]; then
+    avail_mb=$((${avail_kb:-0} / 1024))
+    echo "WARNING: /mnt has only ${avail_mb}MB available, need ${SWAP_SIZE_MB}MB for swap. Skipping swap creation."
+  else
+    sudo fallocate -l "${SWAP_SIZE_GB}G" "$SWAPFILE" || sudo dd if=/dev/zero of="$SWAPFILE" bs=1M count="$SWAP_SIZE_MB"
+    sudo chmod 600 "$SWAPFILE"
+    sudo mkswap "$SWAPFILE"
+    sudo swapon "$SWAPFILE"
+  fi
 else
   echo "Swap already active; skipping creation"
 fi

--- a/scripts/install-oc-tools.sh
+++ b/scripts/install-oc-tools.sh
@@ -149,15 +149,23 @@ restore() {
   fi
 
   if ls "${BIN_PATH}/oc.${VERSION}.bak" 1>/dev/null 2>&1 && ls "${BIN_PATH}/openshift-install.${VERSION}.bak" 1>/dev/null 2>&1 && ls "${BIN_PATH}/kubectl.${VERSION}.bak" 1>/dev/null 2>&1; then
-    read -rp "Found backup of version ${VERSION}. Restore?
-    $(echo -e "\nY/N? ")"
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if [ ! -t 0 ]; then
+      echo "Non-interactive mode: restoring backup of version ${VERSION}..."
       backup restore
       for i in openshift-install oc kubectl; do mv "${BIN_PATH}/${i}.${VERSION}.bak" "${BIN_PATH}/${i}"; done
       show_ver
       exit 0
-    elif [[ $REPLY =~ ^[Nn]$ ]]; then
-      echo "Downloading files..."
+    else
+      read -rp "Found backup of version ${VERSION}. Restore?
+      $(echo -e "\nY/N? ")"
+      if [[ $REPLY =~ ^[Yy]$ ]]; then
+        backup restore
+        for i in openshift-install oc kubectl; do mv "${BIN_PATH}/${i}.${VERSION}.bak" "${BIN_PATH}/${i}"; done
+        show_ver
+        exit 0
+      elif [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo "Downloading files..."
+      fi
     fi
   fi
 
@@ -166,15 +174,23 @@ restore() {
 restore_version() {
 
   if ls "${BIN_PATH}/oc.${1}.bak" 1>/dev/null 2>&1 && ls "${BIN_PATH}/openshift-install.${1}.bak" 1>/dev/null 2>&1 && ls "${BIN_PATH}/kubectl.${1}.bak" 1>/dev/null 2>&1; then
-    read -rp "Found backup of version $1. Restore?
-    $(echo -e "\nY/N? ")"
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if [ ! -t 0 ]; then
+      echo "Non-interactive mode: restoring backup of version ${1}..."
       backup restore
       for i in openshift-install oc kubectl; do mv "${BIN_PATH}/${i}.${1}.bak" "${BIN_PATH}/${i}"; done
       show_ver
       exit 0
-    elif [[ $REPLY =~ ^[Nn]$ ]]; then
-      echo "Downloading files..."
+    else
+      read -rp "Found backup of version $1. Restore?
+      $(echo -e "\nY/N? ")"
+      if [[ $REPLY =~ ^[Yy]$ ]]; then
+        backup restore
+        for i in openshift-install oc kubectl; do mv "${BIN_PATH}/${i}.${1}.bak" "${BIN_PATH}/${i}"; done
+        show_ver
+        exit 0
+      elif [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo "Downloading files..."
+      fi
     fi
   fi
 
@@ -411,6 +427,10 @@ cleanup() {
 remove_old_ver() {
 
   if ls "${BIN_PATH}"/oc*bak 1>/dev/null 2>&1 && ls "${BIN_PATH}"/openshift-install*bak 1>/dev/null 2>&1 && ls "${BIN_PATH}"/kubectl*bak 1>/dev/null 2>&1; then
+    if [ ! -t 0 ]; then
+      echo "Non-interactive mode: skipping cleanup of old versions"
+      exit 0
+    fi
     read -rp "Delete the following files?
 $(echo -e "\n")
 $(for i in oc kubectl openshift-install; do ls -1 "${BIN_PATH}"/$i*bak 2>/dev/null; done)
@@ -437,6 +457,10 @@ uninstall() {
   check_root
 
   if ls "${BIN_PATH}"/oc 1>/dev/null 2>&1 && ls "${BIN_PATH}"/openshift-install 1>/dev/null 2>&1 && ls "${BIN_PATH}"/kubectl 1>/dev/null 2>&1; then
+    if [ ! -t 0 ]; then
+      echo "Non-interactive mode: skipping uninstall"
+      exit 0
+    fi
     read -rp "Delete the following files?
 $(echo -e "\n")
 $(for i in oc kubectl openshift-install; do ls -1 "${BIN_PATH}"/$i 2>/dev/null; done)

--- a/scripts/wait-for-node-ready.sh
+++ b/scripts/wait-for-node-ready.sh
@@ -38,6 +38,7 @@ while ! oc get nodes --request-timeout='30s' &>/dev/null; do
 done
 
 # Wait for the node to be in Ready state
+elapsed=0
 while [[ $(oc get nodes --request-timeout='30s' -o json | jq -r '.items[] | select(.metadata.name=="api.crc.testing") | .status.conditions[] | select(.reason=="KubeletReady") | .status') == "False" ]]; do
   echo "Waiting for node to be in Ready state... (${elapsed}s/${timeout}s)"
   sleep 5

--- a/scripts/wait-for-operators.sh
+++ b/scripts/wait-for-operators.sh
@@ -9,8 +9,18 @@ timeout="${1:-600}"
 elapsed=0
 interval=10
 
+excluded=$(oc get clusterversion/version -ojsonpath='{range .spec.overrides[?(@.kind=="ClusterOperator")]}{.name}{"\n"}{end}' 2>/dev/null || true)
+if [ -n "$excluded" ]; then
+  exclude_pattern=$(echo "$excluded" | paste -sd'|')
+  echo "Excluding unmanaged operators from readiness check: $(echo "$excluded" | paste -sd', ')"
+fi
+
 while true; do
-  co_status=$(oc get co --no-headers)
+  if [ -n "${exclude_pattern:-}" ]; then
+    co_status=$(oc get co --no-headers | grep -v -E "^($exclude_pattern) ")
+  else
+    co_status=$(oc get co --no-headers)
+  fi
   not_ready=$(echo "$co_status" | awk '$3 != "True" || $4 != "False" || $5 != "False" {print "  " $1, "Available="$3, "Progressing="$4, "Degraded="$5}')
 
   if [ -z "$not_ready" ]; then


### PR DESCRIPTION
## Summary
- **#150**: Correct README `crcMemory` minimum from ~9216 MB to 10752 MB to match `configure-crc.sh` validation
- **#147**: Reset `elapsed` counter between the two wait phases in `wait-for-node-ready.sh` so the node-Ready phase gets its own full timeout budget
- **#146**: Add `[ ! -t 0 ]` terminal detection at all 4 `read -rp` sites in `install-oc-tools.sh` — auto-restores valid backups in CI, skips destructive operations (cleanup/uninstall)
- **#131**: Check `/mnt` has enough free space before creating the 8GB swapfile; skip with a warning instead of failing mid-allocation
- **#126**: After restoring bundle cache, verify `.crcbundle` files exist and are above 1GB; remove undersized files so CRC triggers a fresh download instead of failing cryptically
- **#166**: Exclude unmanaged operators from `wait-for-operators.sh` readiness check by querying ClusterVersion overrides, preventing timeouts when `scale-down-nonessential.sh` has disabled them

Fixes #126, #131, #146, #147, #150, #166

## Test plan
- [ ] `make lint` passes (shfmt + shellcheck)
- [ ] CI matrix exercises wait-for-node-ready, install-oc-tools, create-swap, bundle cache, and wait-for-operators paths
- [ ] Verify no regressions in CRC deployment across Ubuntu versions