### PR TITLE
docs: document all inputs and outputs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,15 @@ steps:
 | `crcCpu` | CPU allocation for OpenShift Local | No | `4` |
 | `crcDiskSize` | Disk size in GB for OpenShift Local | No | `31` |
 | `waitForOperatorsReady` | Wait for all operators to be ready | No | `false` |
+| `operatorTimeout` | Timeout in seconds for waiting for operators to become ready | No | `600` |
 | `enableClusterMonitoring` | Enable the cluster monitoring stack (auto-increases memory to 14GiB) | No | `false` |
 | `enableTelemetry` | Enable telemetry for OpenShift Local | No | `true` |
 | `disableConnectivityCheck` | Disable the connectivity check for OpenShift Mirror | No | `false` |
 | `disableResourcePrecheck` | Disable the resource precheck (CPU, memory, disk capacity validation) | No | `false` |
+| `httpProxy` | HTTP proxy URL for CRC (e.g., `http://proxy.example.com:8080`) | No | — |
+| `httpsProxy` | HTTPS proxy URL for CRC (e.g., `http://proxy.example.com:8080`) | No | — |
+| `noProxy` | Comma-separated list of hosts/domains to exclude from proxying | No | — |
+| `proxyCaFile` | Path to a CA certificate file for the proxy | No | — |
 | `preloadImages` | Newline-separated list of container images to preload into the cluster registry | No | — |
 
 ## Outputs
@@ -82,6 +87,9 @@ steps:
 | `api-url` | The OpenShift API server URL (`https://api.crc.testing:6443`) |
 | `console-url` | The OpenShift web console URL |
 | `kubeadmin-password` | The kubeadmin password for cluster authentication (masked in logs) |
+| `kubeconfig-path` | The path to the kubeconfig file for cluster access |
+| `cache-hit` | Whether the CRC bundle cache was hit (`true`, `false`, or `disabled`) |
+| `setup-duration` | Total deployment time in seconds |
 
 # OpenShift Local
 


### PR DESCRIPTION
## Related PRs

| PR | Title | Status |
|----|-------|--------|
| [redhat-best-practices-for-k8s/certsuite#3866](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3866) | docs: align READMEs and MkDocs with the current CLI and config | Merged |
| [redhat-best-practices-for-k8s/checks#52](https://github.com/redhat-best-practices-for-k8s/checks/pull/52) | docs: create CLAUDE.md, update check catalog with 27 missing checks | Merged |
| [redhat-best-practices-for-k8s/certsuite-qe#1546](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1546) | docs: remove phantom preflight feature, update Makefile targets | Merged |
| [palmsoftware/quick-ocp#168](https://github.com/palmsoftware/quick-ocp/pull/168) | docs: document all inputs and outputs in README | Merged |
| [palmsoftware/quick-ocp#169](https://github.com/palmsoftware/quick-ocp/pull/169) | docs: fix README accuracy and add CLAUDE.md | Open |
| [palmsoftware/quick-k8s#460](https://github.com/palmsoftware/quick-k8s/pull/460) | docs: Fix monitoring, cert-manager, Thanos, and Minikube config docs | Merged |
| [palmsoftware/quick-k8s#461](https://github.com/palmsoftware/quick-k8s/pull/461) | docs: comprehensive documentation fixes and improvements | Open |
| [sebrandon1/succulent-cli#143](https://github.com/sebrandon1/succulent-cli/pull/143) | Sync documentation with the current CLI | Open |
| [sebrandon1/bps-operator#156](https://github.com/sebrandon1/bps-operator/pull/156) | docs: fix stale documentation and update CHANGELOG through v0.0.17 | Open |
| [sebrandon1/eyes-and-ears#138](https://github.com/sebrandon1/eyes-and-ears/pull/138) | docs: audit and refresh README, CLAUDE.md, and agent command | Open |
| [sebrandon1/tls-operator-audit#69](https://github.com/sebrandon1/tls-operator-audit/pull/69) | docs: simplify README and add CLAUDE.md | Merged |
| [sebrandon1/cert-manager-scripts#156](https://github.com/sebrandon1/cert-manager-scripts/pull/156) | Consolidate docs, fix discrepancies, and improve prerequisites | Merged |
| [sebrandon1/tls-compliance-operator#458](https://github.com/sebrandon1/tls-compliance-operator/pull/458) | docs: address documentation gaps across five areas | Merged |
| [sebrandon1/go-skylight#415](https://github.com/sebrandon1/go-skylight/pull/415) | docs: fix missing ctx, wrong photo flags, add template and completion docs | Merged |
| [sebrandon1/go-quay#162](https://github.com/sebrandon1/go-quay/pull/162) | docs: fix library guide method names and complete CLI reference | Merged |

## Summary
- Add 5 missing inputs to README: `httpProxy`, `httpsProxy`, `noProxy`, `proxyCaFile`, `operatorTimeout`
- Add 3 missing outputs to README: `kubeconfig-path`, `cache-hit`, `setup-duration`

## Test plan
- [x] Verify all inputs from action.yml are now documented in README
- [x] Verify all outputs from action.yml are now documented in README
- [ ] CI passes

Fixes #139