### PR TITLE
docs: fix README accuracy and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+Guidance for working with the quick-ocp GitHub Action.
+
+## Overview
+
+quick-ocp deploys an OpenShift Local (CRC) cluster on GitHub Actions runners. It is optimized for free-tier runners through aggressive disk cleanup, swap creation, bundle caching, and operator scaling.
+
+## Commands
+
+```bash
+cd quick-ocp
+
+# Lint shell scripts (requires shfmt and shellcheck)
+make lint
+
+# Auto-fix shell script formatting
+make fix-lint
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `action.yml` | Composite action definition (inputs, outputs, step sequence) |
+| `crc-version-pins.json` | Maps OCP versions to CRC versions; documents known issues |
+| `.github/workflows/reusable-ocp-tests.yml` | CI matrix and workflow examples |
+| `scripts/` | Modular shell scripts called from `action.yml` |
+
+## Version Selection
+
+Priority for CRC version resolution:
+
+1. Explicit `crcVersion` input
+2. Pin in `crc-version-pins.json`
+3. Auto-detection via GitHub API (`"auto"` pins)
+
+YAML parsers treat `4.20` as `4.2`; the action normalizes this automatically.
+
+## Supported Runners
+
+Tested on `ubuntu-22.04`, `ubuntu-24.04`, and `ubuntu-26.04`.
+
+- `ubuntu-20.04` is unsupported (libvirt too old).
+- On `ubuntu-26.04`, use OCP `4.22` or `latest` — older OCP versions fail SSH during CRC start.
+
+## External Dependencies
+
+- **OpenShift Mirror** (`mirror.openshift.com`) — CRC binary and bundle downloads (required).
+- **GitHub API** — CRC version auto-detection (optional; non-fatal connectivity check).
+
+## Usage
+
+```yaml
+- uses: palmsoftware/quick-ocp@v1
+  with:
+    ocpPullSecret: $OCP_PULL_SECRET
+    bundleCache: true
+    desiredOCPVersion: "4.19"
+  env:
+    OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
+```
+
+## Release Tags
+
+- `@v1` — major version tag (recommended)
+- `@v1.0.1` — latest patch release
+
+Semantic versioning: `v1.x.y` with `update-major-tag.yml` maintaining the major tag.
+
+## Common Gotchas
+
+1. **Bundle caching**: `bundleCache: true` uses GitHub Actions cache (10 GB limit). Essential on free-tier runners.
+2. **Memory floor**: `crcMemory` minimum is 10752 MB (CRC requirement); default matches this.
+3. **Cluster monitoring**: Auto-increases memory to 14336 MB; allow 60-minute job timeout.
+4. **Disk space**: CRC needs ~25 GB free; action runs quick-cleanup in aggressive mode before setup.
+5. **Connectivity check**: Validates OpenShift Mirror reachability; GitHub API check is non-fatal.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Test Changes](https://github.com/palmsoftware/quick-ocp/actions/workflows/pre-main.yml/badge.svg)](https://github.com/palmsoftware/quick-ocp/actions/workflows/pre-main.yml)
 [![Update Major Version Tag](https://github.com/palmsoftware/quick-ocp/actions/workflows/update-major-tag.yml/badge.svg)](https://github.com/palmsoftware/quick-ocp/actions/workflows/update-major-tag.yml)
 
-Quickly spawns an OCP cluster using [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview) for use on Github Actions.
+Quickly spawns an OCP cluster using [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview) for use on GitHub Actions.
 
 This will work on the free tier lowest resource runners at the moment with additional runner support added later if needed.
 
-Read more about Github Actions runners [here](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners).
+Read more about GitHub Actions runners [here](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners).
 
 If you are looking to quickly spawn Kubernetes in your Action runner, try [quick-k8s](https://github.com/palmsoftware/quick-k8s).
 
@@ -16,19 +16,19 @@ If you are looking to quickly spawn Kubernetes in your Action runner, try [quick
 
 This action is tested on the following GitHub Actions runners:
 
-- `ubuntu-26.04`
+- `ubuntu-26.04` (OCP `4.22` and `latest` only — older OCP versions fail SSH during CRC start)
 - `ubuntu-24.04`
 - `ubuntu-22.04`
 
-# Known Limitations:
+# Known Limitations
 
 - `ubuntu-20.04` is not supported due to the version of `libvirt` available in the mirrors not meeting the minimum version required by OpenShift Local.
 
-# Connectivity Requirements:
+# Connectivity Requirements
 
 This action requires network access to the **OpenShift Mirror** (`https://mirror.openshift.com`) for downloading CRC binaries and OpenShift client tools.
 
-The action includes an automatic connectivity check that runs at the beginning of each workflow. If the OpenShift Mirror is unreachable, the action will fail gracefully with a clear error message.
+The action includes an automatic connectivity check that runs at the beginning of each workflow. It verifies reachability of the OpenShift Mirror (required) and the GitHub API (optional, non-fatal). If the OpenShift Mirror is unreachable, the action will fail gracefully with a clear error message.
 
 You can disable this check by setting `disableConnectivityCheck: true` in your workflow:
 
@@ -39,11 +39,11 @@ with:
 
 Note: Disabling this check is not recommended as it may result in less clear error messages if connectivity issues occur during the workflow.
 
-# Usage:
+# Usage
 
 Basic Usage:
 
-You will need to supply your OCP Pull Secret as a Github Actions Secret.  Your pull secret can be acquired from [here](https://console.redhat.com/openshift/install/pull-secret).  Click on "Download Pull Secret" and copy the contents into your secret.
+You will need to supply your OCP Pull Secret as a GitHub Actions Secret. Your pull secret can be acquired from [here](https://console.redhat.com/openshift/install/pull-secret). Click on "Download Pull Secret" and copy the contents into your secret.
 
 ```yaml
 steps:
@@ -91,16 +91,6 @@ steps:
 | `cache-hit` | Whether the CRC bundle cache was hit (`true`, `false`, or `disabled`) |
 | `setup-duration` | Total deployment time in seconds |
 
-# OpenShift Local
-
-https://developers.redhat.com/products/openshift-local/overview
-
-This is development only environment that is provided by Red Hat that will allow you do some quick testing in a full OpenShift environment.
-
-## References
-
-- [install-oc-tools.sh](./scripts/install-oc-tools.sh) was a script copied from [install-oc-tools](https://github.com/cptmorgan-rh/install-oc-tools) and slightly modified for `aarch64`.
-
 ## OpenShift Version Selection
 
 You can control which OpenShift version is deployed by setting the `desiredOCPVersion` input variable. For example:
@@ -110,12 +100,12 @@ with:
   desiredOCPVersion: 4.18
 ```
 
-- The default is `latest`, which will use the most recent supported version.  If you leave `desiredOCPVersion` blank, you will get the latest version.
+- The default is `latest`, which will use the most recent supported version. If you leave `desiredOCPVersion` blank, you will get the latest version.
 - Supported values are `4.18`, `4.19`, `4.20`, `4.21`, `4.22`, and `latest`.
 
 **Note:** YAML parsers interpret `4.20` as a floating-point number and convert it to `4.2`. The action automatically normalizes this back to `4.20`, so you don't need to quote version numbers in your workflow files.
 
-For more details, see the [action.yml](action.yml) and workflow examples.
+For more details, see [action.yml](action.yml) and the [reusable workflow examples](.github/workflows/reusable-ocp-tests.yml).
 
 ## CRC Version Control
 
@@ -233,7 +223,7 @@ Lines starting with `#` and blank lines are ignored, so you can comment your ima
 **Mitigations:**
 - The action automatically creates swap on `/mnt` and protects CRC/QEMU processes from the OOM killer.
 - Use `bundleCache: true` to avoid downloading the 3-5 GB bundle during the job, freeing memory during the critical startup window.
-- Reduce `crcMemory` if your tests don't need the full allocation (minimum 10752 MB, which is CRC's recommended minimum).
+- Do not increase `crcMemory` above what your tests require. The default of 10,752 MB is CRC's minimum; lowering it is not supported.
 - Avoid running memory-intensive steps before `crc start` completes.
 
 ### Disk Space Exhaustion
@@ -251,7 +241,7 @@ Lines starting with `#` and blank lines are ignored, so you can comment your ima
 
 **Symptom:** The `Run setup` step fails after one or more retries with errors like `Failed to connect to the CRC VM with SSH`, `connection refused`, or `Failed to update pull secret`.
 
-**Cause:** CRC start can fail transiently due to VM boot timing, SSH connectivity, or resource pressure. The action retries up to 3 times with a 30-second delay between attempts.
+**Cause:** CRC start can fail transiently due to VM boot timing, SSH connectivity, or resource pressure. The action retries up to 3 times with a 10-second delay between attempts.
 
 **What to check:**
 - Expand the **CRC Setup and Start** group in the job log to see the full output from each attempt.
@@ -273,9 +263,13 @@ Lines starting with `#` and blank lines are ignored, so you can comment your ima
 
 **Symptom:** The job fails at the `Check connectivity to required services` step.
 
-**Cause:** The OpenShift Mirror (`mirror.openshift.com`) or Red Hat SSO is unreachable. This can happen during Red Hat maintenance windows.
+**Cause:** The OpenShift Mirror (`mirror.openshift.com`) is unreachable. This can happen during Red Hat maintenance windows.
 
 **What to check:**
 - Check [Red Hat Status](https://status.redhat.com/) for ongoing incidents.
 - The GitHub API connectivity check is non-fatal — a warning is logged but the job continues.
 - If the mirror is consistently down, you can use `disableConnectivityCheck: true` to skip the check, but the download step will still fail if the mirror is actually unreachable.
+
+## References
+
+- [install-oc-tools.sh](./scripts/install-oc-tools.sh) was adapted from [install-oc-tools](https://github.com/cptmorgan-rh/install-oc-tools) with modifications for `aarch64`.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Quick OCP'
-description: 'Quickly deploy an OpenShift cluster on Github Actions hosted runners'
+description: 'Quickly deploy an OpenShift cluster on GitHub Actions hosted runners'
 inputs:
   ocpPullSecret:
     description: 'Pull secret for OpenShift Local'


### PR DESCRIPTION
## Related PRs

| PR | Title | Status |
|----|-------|--------|
| [redhat-best-practices-for-k8s/certsuite#3866](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3866) | docs: align READMEs and MkDocs with the current CLI and config | Merged |
| [redhat-best-practices-for-k8s/checks#52](https://github.com/redhat-best-practices-for-k8s/checks/pull/52) | docs: create CLAUDE.md, update check catalog with 27 missing checks | Merged |
| [redhat-best-practices-for-k8s/certsuite-qe#1546](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1546) | docs: remove phantom preflight feature, update Makefile targets | Merged |
| [palmsoftware/quick-ocp#168](https://github.com/palmsoftware/quick-ocp/pull/168) | docs: document all inputs and outputs in README | Merged |
| [palmsoftware/quick-ocp#169](https://github.com/palmsoftware/quick-ocp/pull/169) | docs: fix README accuracy and add CLAUDE.md | Open |
| [palmsoftware/quick-k8s#460](https://github.com/palmsoftware/quick-k8s/pull/460) | docs: Fix monitoring, cert-manager, Thanos, and Minikube config docs | Merged |
| [palmsoftware/quick-k8s#461](https://github.com/palmsoftware/quick-k8s/pull/461) | docs: comprehensive documentation fixes and improvements | Open |
| [sebrandon1/succulent-cli#143](https://github.com/sebrandon1/succulent-cli/pull/143) | Sync documentation with the current CLI | Open |
| [sebrandon1/bps-operator#156](https://github.com/sebrandon1/bps-operator/pull/156) | docs: fix stale documentation and update CHANGELOG through v0.0.17 | Open |
| [sebrandon1/eyes-and-ears#138](https://github.com/sebrandon1/eyes-and-ears/pull/138) | docs: audit and refresh README, CLAUDE.md, and agent command | Open |
| [sebrandon1/tls-operator-audit#69](https://github.com/sebrandon1/tls-operator-audit/pull/69) | docs: simplify README and add CLAUDE.md | Merged |
| [sebrandon1/cert-manager-scripts#156](https://github.com/sebrandon1/cert-manager-scripts/pull/156) | Consolidate docs, fix discrepancies, and improve prerequisites | Merged |
| [sebrandon1/tls-compliance-operator#458](https://github.com/sebrandon1/tls-compliance-operator/pull/458) | docs: address documentation gaps across five areas | Merged |
| [sebrandon1/go-skylight#415](https://github.com/sebrandon1/go-skylight/pull/415) | docs: fix missing ctx, wrong photo flags, add template and completion docs | Merged |
| [sebrandon1/go-quay#162](https://github.com/sebrandon1/go-quay/pull/162) | docs: fix library guide method names and complete CLI reference | Merged |

## Summary

- Fix factual errors in README troubleshooting (CRC retry delay, connectivity checks, crcMemory guidance)
- Document ubuntu-26.04 OCP version limits and link to reusable workflow examples
- Simplify README structure (remove redundant OpenShift Local section, normalize headings, fix GitHub capitalization)
- Add project-specific `CLAUDE.md` with commands, version selection, runner caveats, and common gotchas
- Fix `Github` → `GitHub` typo in `action.yml` description

## Test plan

- [x] Verified all README hyperlinks return HTTP 200 (except developers.redhat.com, which is bot-protected but valid)
- [x] Confirmed YAML examples parse correctly
- [x] Confirmed inputs/outputs table matches `action.yml`
- [x] Confirmed CRC retry delay (10s) and connectivity checks match `scripts/run-crc-setup.sh` and `scripts/check-connectivity.sh`
- [x] Confirmed ubuntu-26.04 matrix exclusions match `.github/workflows/reusable-ocp-tests.yml`